### PR TITLE
feat: Multi-mission architecture — event bus, state machine, module registry

### DIFF
--- a/configurator/configurator_app.py
+++ b/configurator/configurator_app.py
@@ -1,74 +1,253 @@
-"""UniSat Mission Configurator — Web-based mission builder."""
+"""UniSat Mission Configurator — Multi-platform web-based mission builder.
+
+Supports CubeSat, CanSat, rocket, HAB, drone, and custom platforms.
+Generates mission_config.json with the appropriate mission_type, phases,
+and subsystem configuration for the selected platform and competition.
+"""
 
 import json
 import streamlit as st
 
 st.set_page_config(page_title="UniSat Configurator", layout="wide")
-st.title("🔧 UniSat Mission Configurator")
+st.title("UniSat Mission Configurator")
 
-# Form factor
-form_factor = st.selectbox("Form Factor", ["1U", "2U", "3U", "6U"], index=2)
-mass_limits = {"1U": 1.33, "2U": 2.66, "3U": 4.0, "6U": 12.0}
-panel_counts = {"1U": 4, "2U": 4, "3U": 6, "6U": 8}
+# ---- Platform & Mission Type Selection ----
 
-# Orbit
-st.markdown("### Orbit Configuration")
-c1, c2, c3 = st.columns(3)
-orbit_type = c1.selectbox("Orbit Type", ["LEO", "SSO", "ISS", "Custom"])
-altitude = c2.number_input("Altitude (km)", 200, 2000, 550)
-inclination = c3.number_input("Inclination (°)", 0.0, 180.0, 97.6)
+PLATFORM_OPTIONS = {
+    "CubeSat": {
+        "mission_types": ["cubesat_leo", "cubesat_sso", "cubesat_tech_demo"],
+        "form_factors": ["1U", "2U", "3U", "6U", "12U"],
+        "description": "Orbital CubeSat missions (LEO, SSO, ISS)",
+    },
+    "CanSat": {
+        "mission_types": ["cansat_standard", "cansat_advanced"],
+        "form_factors": ["cansat_standard", "cansat_custom"],
+        "description": "CanSat competitions (ESERO, AAS, national)",
+    },
+    "Suborbital Rocket": {
+        "mission_types": ["rocket_sounding", "rocket_competition"],
+        "form_factors": ["rocket_avionics", "rocket_custom"],
+        "description": "Rocketry competitions (SA Cup, IREC, Team America)",
+    },
+    "High Altitude Balloon": {
+        "mission_types": ["hab_standard", "hab_long_duration"],
+        "form_factors": ["hab_payload_small", "hab_payload_medium", "hab_payload_large"],
+        "description": "HAB flights and competitions",
+    },
+    "Drone / UAV": {
+        "mission_types": ["drone_survey", "drone_inspection"],
+        "form_factors": ["drone_small", "drone_medium"],
+        "description": "UAV survey, inspection, and competition missions",
+    },
+    "Custom": {
+        "mission_types": ["custom"],
+        "form_factors": ["custom"],
+        "description": "User-defined platform and mission phases",
+    },
+}
 
-# Subsystems
+st.markdown("### Platform Selection")
+platform_name = st.selectbox(
+    "Platform",
+    list(PLATFORM_OPTIONS.keys()),
+    index=0,
+)
+platform = PLATFORM_OPTIONS[platform_name]
+st.caption(platform["description"])
+
+col_mt, col_ff = st.columns(2)
+mission_type = col_mt.selectbox("Mission Type", platform["mission_types"])
+form_factor = col_ff.selectbox("Form Factor", platform["form_factors"])
+
+# ---- Platform-specific configuration ----
+
+st.markdown("---")
+
+mission_name = st.text_input("Mission Name", "UniSat-1")
+
+if platform_name == "CubeSat":
+    st.markdown("### Orbit Configuration")
+    c1, c2, c3 = st.columns(3)
+    orbit_type = c1.selectbox("Orbit Type", ["LEO", "SSO", "ISS", "Custom"])
+    altitude = c2.number_input("Altitude (km)", 200, 2000, 550)
+    inclination = c3.number_input("Inclination (deg)", 0.0, 180.0, 97.6)
+    show_orbit = True
+else:
+    show_orbit = False
+    orbit_type = "N/A"
+    altitude = 0
+    inclination = 0.0
+
+# ---- Subsystems (platform-aware) ----
+
 st.markdown("### Subsystems")
-col1, col2 = st.columns(2)
-with col1:
-    obc = st.checkbox("OBC (STM32F4)", value=True, disabled=True)
-    eps = st.checkbox("EPS (Solar + Battery)", value=True)
-    comm_uhf = st.checkbox("COMM UHF (437 MHz)", value=True)
-    comm_sband = st.checkbox("COMM S-band (2.4 GHz)", value=True)
-with col2:
-    adcs = st.checkbox("ADCS (Magnetorquers + Wheels)", value=True)
-    gnss = st.checkbox("GNSS (u-blox)", value=True)
-    camera = st.checkbox("Camera (8MP)", value=True)
-    payload = st.checkbox("Payload Module", value=True)
 
-# Validation
+PLATFORM_SUBSYSTEMS = {
+    "CubeSat": {
+        "obc": ("OBC (STM32F4)", True, True),
+        "eps": ("EPS (Solar + Battery)", True, False),
+        "comm_uhf": ("COMM UHF", True, False),
+        "comm_sband": ("COMM S-band", True, False),
+        "adcs": ("ADCS (Magnetorquers + Wheels)", True, False),
+        "gnss": ("GNSS (u-blox)", True, False),
+        "camera": ("Camera (8MP)", True, False),
+        "payload": ("Payload Module", True, False),
+    },
+    "CanSat": {
+        "obc": ("OBC (STM32F4)", True, True),
+        "imu": ("IMU (Accelerometer + Gyro)", True, False),
+        "barometer": ("Barometric Altimeter", True, False),
+        "gnss": ("GNSS (u-blox)", True, False),
+        "comm_uhf": ("COMM Radio (433/915 MHz)", True, False),
+        "descent_controller": ("Descent Controller", True, False),
+        "camera": ("Camera", False, False),
+        "payload": ("Custom Payload", True, False),
+    },
+    "Suborbital Rocket": {
+        "obc": ("OBC (STM32F4)", True, True),
+        "imu": ("IMU (High-G)", True, False),
+        "barometer": ("Barometric Altimeter", True, False),
+        "gnss": ("GNSS (u-blox)", True, False),
+        "comm_uhf": ("COMM Radio (915 MHz)", True, False),
+        "camera": ("Camera", False, False),
+        "payload": ("Experiment Payload", True, False),
+    },
+    "High Altitude Balloon": {
+        "obc": ("OBC (STM32F4)", True, True),
+        "barometer": ("Barometric Altimeter", True, False),
+        "gnss": ("GNSS (u-blox)", True, False),
+        "comm_uhf": ("COMM UHF / RTTY", True, False),
+        "camera": ("Camera (Wide-angle)", True, False),
+        "imu": ("IMU", False, False),
+        "payload": ("Environmental Sensors", True, False),
+    },
+    "Drone / UAV": {
+        "obc": ("OBC (STM32F4)", True, True),
+        "imu": ("IMU (Flight Controller)", True, False),
+        "barometer": ("Barometric Altimeter", True, False),
+        "gnss": ("GNSS (u-blox)", True, False),
+        "comm_uhf": ("COMM (2.4 GHz MAVLink)", True, False),
+        "camera": ("Camera (Multispectral)", True, False),
+        "payload": ("Survey Payload", True, False),
+    },
+    "Custom": {
+        "obc": ("OBC (STM32F4)", True, True),
+        "imu": ("IMU", False, False),
+        "barometer": ("Barometric Altimeter", False, False),
+        "eps": ("EPS (Solar + Battery)", False, False),
+        "comm_uhf": ("COMM Radio", False, False),
+        "adcs": ("ADCS", False, False),
+        "gnss": ("GNSS", False, False),
+        "camera": ("Camera", False, False),
+        "descent_controller": ("Descent Controller", False, False),
+        "payload": ("Payload Module", False, False),
+    },
+}
+
+subsystem_defs = PLATFORM_SUBSYSTEMS.get(platform_name, PLATFORM_SUBSYSTEMS["Custom"])
+enabled = {}
+col1, col2 = st.columns(2)
+items = list(subsystem_defs.items())
+half = (len(items) + 1) // 2
+for i, (key, (label, default_val, disabled)) in enumerate(items):
+    col = col1 if i < half else col2
+    enabled[key] = col.checkbox(label, value=default_val, disabled=disabled, key=f"sub_{key}")
+
+# ---- Competition-specific settings ----
+
+competition_config = {}
+if platform_name == "CanSat":
+    st.markdown("### CanSat Competition Settings")
+    c1, c2, c3 = st.columns(3)
+    competition_config["descent_rate_min"] = c1.number_input("Min descent rate (m/s)", 1.0, 20.0, 6.0)
+    competition_config["descent_rate_max"] = c2.number_input("Max descent rate (m/s)", 1.0, 30.0, 11.0)
+    competition_config["max_landing_velocity"] = c3.number_input("Max landing velocity (m/s)", 1.0, 30.0, 12.0)
+    competition_config["deploy_altitude_m"] = st.number_input("Deploy altitude (m AGL)", 100, 2000, 500)
+
+elif platform_name == "Suborbital Rocket":
+    st.markdown("### Rocket Competition Settings")
+    c1, c2 = st.columns(2)
+    competition_config["target_altitude_m"] = c1.number_input("Target altitude (m)", 100, 30000, 3048)
+    competition_config["dual_deploy"] = c2.checkbox("Dual deploy (drogue + main)", value=True)
+
+elif platform_name == "High Altitude Balloon":
+    st.markdown("### HAB Flight Settings")
+    c1, c2 = st.columns(2)
+    competition_config["target_altitude_m"] = c1.number_input("Target altitude (m)", 10000, 40000, 30000)
+    competition_config["expected_ascent_rate"] = c2.number_input("Expected ascent rate (m/s)", 1.0, 10.0, 5.0)
+
+elif platform_name == "Drone / UAV":
+    st.markdown("### Drone Mission Settings")
+    c1, c2, c3 = st.columns(3)
+    competition_config["max_altitude_m"] = c1.number_input("Max altitude (m)", 10, 500, 120)
+    competition_config["max_flight_time_min"] = c2.number_input("Max flight time (min)", 5, 120, 30)
+    competition_config["geofence_radius_m"] = c3.number_input("Geofence radius (m)", 50, 5000, 500)
+
+# ---- Budget Validation ----
+
 st.markdown("---")
 st.markdown("### Budget Validation")
 
-mass_items = {"OBC": 0.15, "EPS": 0.8, "COMM": 0.2, "ADCS": 0.6,
-              "GNSS": 0.05, "Camera": 0.3, "Payload": 0.2, "Structure": 0.5}
-total_mass = sum(mass_items.values())
-mass_limit = mass_limits[form_factor]
+from validators.mass_validator import validate_mass, FORM_FACTOR_LIMITS
+from validators.volume_validator import validate_volume, FORM_FACTOR_VOLUMES
+
+mass_result = validate_mass(form_factor, enabled)
+vol_result = validate_volume(form_factor, enabled)
 
 c1, c2, c3 = st.columns(3)
-mass_ok = total_mass <= mass_limit
-c1.metric("Total Mass", f"{total_mass:.2f} kg",
-          f"{'OK' if mass_ok else 'OVER'} (limit: {mass_limit} kg)")
+c1.metric(
+    "Mass",
+    f"{mass_result.total_kg:.2f} kg",
+    f"{'OK' if mass_result.valid else 'OVER'} (limit: {mass_result.limit_kg} kg)",
+)
+c2.metric(
+    "Volume",
+    f"{vol_result.total_cm3:.0f} cm3",
+    f"{vol_result.utilization_pct:.0f}% used ({vol_result.available_cm3:.0f} cm3 avail)",
+)
+c3.metric("Platform", platform_name, f"Type: {mission_type}")
 
-power_gen = panel_counts[form_factor] * 0.06 * 1361 * 0.295 * 0.5
-power_use = 3.5
-power_ok = power_gen > power_use
-c2.metric("Power Balance", f"+{power_gen - power_use:.1f} W",
-          f"Gen: {power_gen:.1f}W, Use: {power_use:.1f}W")
+# ---- Config Generation ----
 
-c3.metric("Form Factor", form_factor, f"{panel_counts[form_factor]} panels")
-
-# Generate config
+st.markdown("---")
 if st.button("Generate mission_config.json", type="primary"):
-    config = {
-        "mission": {"name": "UniSat-1", "version": "1.0.0"},
-        "satellite": {"form_factor": form_factor, "mass_kg": total_mass},
-        "orbit": {"type": orbit_type, "altitude_km": altitude,
-                  "inclination_deg": inclination},
-        "subsystems": {
-            "obc": {"enabled": True}, "eps": {"enabled": eps},
-            "comm": {"enabled": comm_uhf, "uhf": {"enabled": comm_uhf},
-                     "s_band": {"enabled": comm_sband}},
-            "adcs": {"enabled": adcs}, "gnss": {"enabled": gnss},
-            "camera": {"enabled": camera}, "payload": {"enabled": payload},
+    config: dict = {
+        "mission": {
+            "name": mission_name,
+            "version": "1.0.0",
+            "description": f"{platform_name} mission",
+            "mission_type": mission_type,
+            "platform": platform_name.lower().replace(" / ", "_").replace(" ", "_"),
+            "operator": "Team Name",
+            "telemetry_hz": {
+                "CubeSat": 1.0, "CanSat": 10.0, "Suborbital Rocket": 20.0,
+                "High Altitude Balloon": 0.5, "Drone / UAV": 10.0, "Custom": 1.0,
+            }.get(platform_name, 1.0),
         },
+        "satellite": {
+            "form_factor": form_factor,
+            "mass_kg": mass_result.total_kg,
+        },
+        "subsystems": {},
     }
+
+    if show_orbit:
+        config["orbit"] = {
+            "type": orbit_type,
+            "altitude_km": altitude,
+            "inclination_deg": inclination,
+        }
+
+    for key, is_enabled in enabled.items():
+        config["subsystems"][key] = {"enabled": is_enabled}
+
+    if competition_config:
+        config["mission"]["competition"] = competition_config
+
     st.json(config)
-    st.download_button("Download", json.dumps(config, indent=2),
-                       "mission_config.json", "application/json")
+    st.download_button(
+        "Download",
+        json.dumps(config, indent=2),
+        "mission_config.json",
+        "application/json",
+    )

--- a/configurator/generators/config_generator.py
+++ b/configurator/generators/config_generator.py
@@ -1,72 +1,111 @@
-"""Config Generator — Build mission_config.json from user selections."""
+"""Config Generator — Build mission_config.json for any platform type."""
 
 import json
+from pathlib import Path
 from typing import Any
+
+
+# Default templates per mission type
+_TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
 
 
 def generate_config(
     mission_name: str = "UniSat-1",
+    mission_type: str = "cubesat_leo",
+    platform: str = "cubesat",
     form_factor: str = "3U",
     orbit_type: str = "SSO",
     altitude_km: float = 550,
     inclination_deg: float = 97.6,
+    telemetry_hz: float = 1.0,
     subsystems: dict[str, bool] | None = None,
     gs_lat: float = 41.2995,
     gs_lon: float = 69.2401,
+    competition: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Generate a complete mission_config.json."""
+    """Generate a complete mission_config.json for any platform.
+
+    Args:
+        mission_name: Human-readable mission name.
+        mission_type: Mission type string (e.g. "cansat_standard").
+        platform: Platform category (e.g. "cubesat", "cansat").
+        form_factor: Physical form factor.
+        orbit_type: Orbit type (for orbital missions).
+        altitude_km: Orbital altitude (for orbital missions).
+        inclination_deg: Orbital inclination (for orbital missions).
+        telemetry_hz: Telemetry rate.
+        subsystems: Dict of subsystem name -> enabled bool.
+        gs_lat: Ground station latitude.
+        gs_lon: Ground station longitude.
+        competition: Optional competition-specific config dict.
+
+    Returns:
+        Complete mission configuration dict.
+    """
     if subsystems is None:
-        subsystems = {
-            "obc": True, "eps": True, "comm": True, "adcs": True,
-            "gnss": True, "camera": True, "payload": True,
-        }
+        subsystems = {"obc": True}
 
-    mass_map = {"1U": 1.33, "2U": 2.66, "3U": 4.0, "6U": 12.0}
-    dim_map = {
-        "1U": [100, 100, 113.5], "2U": [100, 100, 227.0],
-        "3U": [100, 100, 340.5], "6U": [100, 226.3, 340.5],
-    }
-    panel_map = {"1U": 4, "2U": 4, "3U": 6, "6U": 8}
-
-    config = {
+    config: dict[str, Any] = {
         "mission": {
-            "name": mission_name, "version": "1.0.0",
-            "description": "Universal modular CubeSat platform",
-            "operator": "Team Name", "launch_date": "2026-01-01T00:00:00Z",
+            "name": mission_name,
+            "version": "1.0.0",
+            "description": f"{platform} mission",
+            "mission_type": mission_type,
+            "platform": platform,
+            "operator": "Team Name",
+            "telemetry_hz": telemetry_hz,
         },
         "satellite": {
-            "form_factor": form_factor, "mass_kg": mass_map.get(form_factor, 4.0),
-            "dimensions_mm": dim_map.get(form_factor, [100, 100, 340.5]),
+            "form_factor": form_factor,
         },
-        "orbit": {
-            "type": orbit_type, "altitude_km": altitude_km,
-            "inclination_deg": inclination_deg, "expected_lifetime_years": 2,
-        },
-        "subsystems": {
-            "obc": {"enabled": True, "mcu": "STM32F446RE", "clock_mhz": 180},
-            "eps": {
-                "enabled": subsystems.get("eps", True),
-                "solar_panels": panel_map.get(form_factor, 6),
-                "panel_efficiency": 0.295, "battery_capacity_wh": 30,
-                "bus_voltage": 5.0,
-            },
-            "comm": {
-                "enabled": subsystems.get("comm", True),
-                "uhf": {"enabled": True, "frequency_mhz": 437.0, "data_rate_bps": 9600},
-                "s_band": {"enabled": True, "frequency_mhz": 2400, "data_rate_kbps": 256},
-            },
-            "adcs": {"enabled": subsystems.get("adcs", True)},
-            "gnss": {"enabled": subsystems.get("gnss", True)},
-            "camera": {"enabled": subsystems.get("camera", True)},
-            "payload": {"enabled": subsystems.get("payload", True), "type": "radiation_monitor"},
-        },
-        "ground_station": {
-            "location": {"name": "Ground Station", "latitude": gs_lat,
-                         "longitude": gs_lon, "altitude_m": 455},
-            "antenna": {"type": "yagi", "gain_dbi": 14, "frequency_mhz": 437},
+        "subsystems": {},
+    }
+
+    # Add orbit section only for orbital missions
+    if platform == "cubesat":
+        config["orbit"] = {
+            "type": orbit_type,
+            "altitude_km": altitude_km,
+            "inclination_deg": inclination_deg,
+            "expected_lifetime_years": 2,
+        }
+
+    # Add subsystems
+    for name, enabled in subsystems.items():
+        config["subsystems"][name] = {"enabled": enabled}
+
+    # Add ground station
+    config["ground_station"] = {
+        "location": {
+            "name": "Ground Station",
+            "latitude": gs_lat,
+            "longitude": gs_lon,
+            "altitude_m": 0,
         },
     }
+
+    # Add competition config
+    if competition:
+        config["mission"]["competition"] = competition
+
     return config
+
+
+def load_template(mission_type: str) -> dict[str, Any] | None:
+    """Load a mission template by type.
+
+    Args:
+        mission_type: Mission type string.
+
+    Returns:
+        Template config dict, or None if not found.
+    """
+    templates_dir = Path(__file__).parent.parent.parent / "mission_templates"
+    template_path = templates_dir / f"{mission_type}.json"
+    if template_path.exists():
+        with open(template_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return None
 
 
 def save_config(config: dict, path: str = "mission_config.json") -> None:

--- a/configurator/validators/mass_validator.py
+++ b/configurator/validators/mass_validator.py
@@ -1,15 +1,49 @@
-"""Mass Validator — Check satellite mass budget against limits."""
+"""Mass Validator — Check mass budget for all platform types."""
 
 from dataclasses import dataclass
 
-FORM_FACTOR_LIMITS = {"1U": 1.33, "2U": 2.66, "3U": 4.0, "6U": 12.0}
+# Mass limits by form factor (kg)
+FORM_FACTOR_LIMITS: dict[str, float] = {
+    # CubeSat
+    "1U": 1.33, "2U": 2.66, "3U": 4.0, "6U": 12.0, "12U": 24.0,
+    # CanSat
+    "cansat_standard": 0.35, "cansat_custom": 0.5,
+    # Rocket avionics
+    "rocket_avionics": 0.5, "rocket_custom": 2.0,
+    # HAB payloads
+    "hab_payload_small": 1.0, "hab_payload_medium": 2.0, "hab_payload_large": 5.0,
+    # Drone
+    "drone_small": 2.5, "drone_medium": 5.0,
+    # Custom
+    "custom": 10.0,
+}
 
-COMPONENT_MASSES = {
-    "obc": 0.15, "eps_board": 0.10, "battery_pack": 0.50, "solar_panels": 0.20,
-    "comm_uhf": 0.10, "comm_sband": 0.12, "adcs_magnetorquers": 0.15,
-    "adcs_reaction_wheels": 0.35, "adcs_sensors": 0.08, "gnss": 0.05,
-    "camera": 0.30, "payload": 0.20, "structure": 0.50, "harness": 0.15,
-    "thermal": 0.10, "margin_20pct": 0.0,
+# Component masses (kg) — shared across platforms
+COMPONENT_MASSES: dict[str, float] = {
+    # Common
+    "obc": 0.15, "harness": 0.15, "structure": 0.50,
+    # EPS
+    "eps_board": 0.10, "battery_pack": 0.50, "solar_panels": 0.20,
+    # Comms
+    "comm_uhf": 0.10, "comm_sband": 0.12,
+    # ADCS
+    "adcs_magnetorquers": 0.15, "adcs_reaction_wheels": 0.35, "adcs_sensors": 0.08,
+    # Sensors
+    "gnss": 0.05, "imu": 0.02, "barometer": 0.01,
+    # Payload
+    "camera": 0.30, "payload": 0.20,
+    # CanSat / rocket specific
+    "descent_controller": 0.03, "thermal": 0.10,
+    # Margin placeholder
+    "margin_20pct": 0.0,
+}
+
+# Platform-specific structure mass overrides
+STRUCTURE_MASS: dict[str, float] = {
+    "cansat_standard": 0.05, "cansat_custom": 0.08,
+    "rocket_avionics": 0.10, "rocket_custom": 0.15,
+    "hab_payload_small": 0.15, "hab_payload_medium": 0.25, "hab_payload_large": 0.40,
+    "drone_small": 0.80, "drone_medium": 1.50,
 }
 
 
@@ -27,32 +61,44 @@ class MassResult:
 def validate_mass(form_factor: str, enabled_subsystems: dict[str, bool]) -> MassResult:
     """Validate mass budget for given configuration."""
     limit = FORM_FACTOR_LIMITS.get(form_factor, 4.0)
-    items = {}
+    items: dict[str, float] = {}
 
-    items["structure"] = COMPONENT_MASSES["structure"]
+    # Structure (platform-specific)
+    items["structure"] = STRUCTURE_MASS.get(form_factor, COMPONENT_MASSES["structure"])
     items["harness"] = COMPONENT_MASSES["harness"]
-    items["thermal"] = COMPONENT_MASSES["thermal"]
     items["obc"] = COMPONENT_MASSES["obc"]
 
-    if enabled_subsystems.get("eps", True):
+    # Thermal (only CubeSat)
+    if form_factor in ("1U", "2U", "3U", "6U", "12U"):
+        items["thermal"] = COMPONENT_MASSES["thermal"]
+
+    if enabled_subsystems.get("eps", False):
         items["eps_board"] = COMPONENT_MASSES["eps_board"]
         items["battery_pack"] = COMPONENT_MASSES["battery_pack"]
         items["solar_panels"] = COMPONENT_MASSES["solar_panels"]
 
-    if enabled_subsystems.get("comm_uhf", True):
+    if enabled_subsystems.get("comm_uhf", False):
         items["comm_uhf"] = COMPONENT_MASSES["comm_uhf"]
     if enabled_subsystems.get("comm_sband", False):
         items["comm_sband"] = COMPONENT_MASSES["comm_sband"]
-    if enabled_subsystems.get("adcs", True):
+
+    if enabled_subsystems.get("adcs", False):
         items["adcs_magnetorquers"] = COMPONENT_MASSES["adcs_magnetorquers"]
         items["adcs_reaction_wheels"] = COMPONENT_MASSES["adcs_reaction_wheels"]
         items["adcs_sensors"] = COMPONENT_MASSES["adcs_sensors"]
-    if enabled_subsystems.get("gnss", True):
+
+    if enabled_subsystems.get("gnss", False):
         items["gnss"] = COMPONENT_MASSES["gnss"]
-    if enabled_subsystems.get("camera", True):
+    if enabled_subsystems.get("imu", False):
+        items["imu"] = COMPONENT_MASSES["imu"]
+    if enabled_subsystems.get("barometer", False):
+        items["barometer"] = COMPONENT_MASSES["barometer"]
+    if enabled_subsystems.get("camera", False):
         items["camera"] = COMPONENT_MASSES["camera"]
-    if enabled_subsystems.get("payload", True):
+    if enabled_subsystems.get("payload", False):
         items["payload"] = COMPONENT_MASSES["payload"]
+    if enabled_subsystems.get("descent_controller", False):
+        items["descent_controller"] = COMPONENT_MASSES["descent_controller"]
 
     subtotal = sum(items.values())
     margin_20 = subtotal * 0.20
@@ -62,6 +108,6 @@ def validate_mass(form_factor: str, enabled_subsystems: dict[str, bool]) -> Mass
     return MassResult(
         total_kg=round(total, 3), limit_kg=limit,
         margin_kg=round(limit - total, 3),
-        margin_pct=round((limit - total) / limit * 100, 1),
+        margin_pct=round((limit - total) / limit * 100, 1) if limit > 0 else 0.0,
         valid=total <= limit, items=items,
     )

--- a/configurator/validators/volume_validator.py
+++ b/configurator/validators/volume_validator.py
@@ -1,19 +1,38 @@
-"""Volume Validator — Check component fit within CubeSat form factor."""
+"""Volume Validator — Check component fit for all platform types."""
 
 from dataclasses import dataclass
 
-FORM_FACTOR_VOLUMES = {
+# Volume specs by form factor
+FORM_FACTOR_VOLUMES: dict[str, dict[str, float]] = {
+    # CubeSat standards
     "1U": {"x_mm": 100, "y_mm": 100, "z_mm": 113.5, "volume_cm3": 1135},
     "2U": {"x_mm": 100, "y_mm": 100, "z_mm": 227.0, "volume_cm3": 2270},
     "3U": {"x_mm": 100, "y_mm": 100, "z_mm": 340.5, "volume_cm3": 3405},
     "6U": {"x_mm": 100, "y_mm": 226.3, "z_mm": 340.5, "volume_cm3": 7704},
+    "12U": {"x_mm": 226.3, "y_mm": 226.3, "z_mm": 340.5, "volume_cm3": 17438},
+    # CanSat
+    "cansat_standard": {"x_mm": 66, "y_mm": 66, "z_mm": 115, "volume_cm3": 393},
+    "cansat_custom": {"x_mm": 80, "y_mm": 80, "z_mm": 150, "volume_cm3": 960},
+    # Rocket
+    "rocket_avionics": {"x_mm": 50, "y_mm": 50, "z_mm": 100, "volume_cm3": 250},
+    "rocket_custom": {"x_mm": 80, "y_mm": 80, "z_mm": 200, "volume_cm3": 1280},
+    # HAB
+    "hab_payload_small": {"x_mm": 150, "y_mm": 150, "z_mm": 100, "volume_cm3": 2250},
+    "hab_payload_medium": {"x_mm": 200, "y_mm": 200, "z_mm": 150, "volume_cm3": 6000},
+    "hab_payload_large": {"x_mm": 300, "y_mm": 300, "z_mm": 200, "volume_cm3": 18000},
+    # Drone
+    "drone_small": {"x_mm": 200, "y_mm": 200, "z_mm": 100, "volume_cm3": 4000},
+    "drone_medium": {"x_mm": 300, "y_mm": 300, "z_mm": 150, "volume_cm3": 13500},
+    # Custom
+    "custom": {"x_mm": 200, "y_mm": 200, "z_mm": 200, "volume_cm3": 8000},
 }
 
-COMPONENT_VOLUMES_CM3 = {
+COMPONENT_VOLUMES_CM3: dict[str, float] = {
     "obc_board": 50, "eps_board": 60, "battery_pack": 200,
     "comm_uhf": 40, "comm_sband": 50, "adcs_unit": 150,
-    "gnss_module": 15, "camera_module": 80, "payload_module": 100,
-    "harness_misc": 50,
+    "gnss_module": 15, "imu_module": 5, "barometer_module": 3,
+    "camera_module": 80, "payload_module": 100,
+    "descent_controller_module": 20, "harness_misc": 50,
 }
 
 
@@ -29,31 +48,39 @@ class VolumeResult:
 
 def validate_volume(form_factor: str,
                     enabled_subsystems: dict[str, bool]) -> VolumeResult:
-    """Validate volume budget."""
-    specs = FORM_FACTOR_VOLUMES.get(form_factor, FORM_FACTOR_VOLUMES["3U"])
-    available = specs["volume_cm3"]
+    """Validate volume budget for given configuration."""
+    specs = FORM_FACTOR_VOLUMES.get(form_factor, FORM_FACTOR_VOLUMES.get("3U", {}))
+    available = specs.get("volume_cm3", 3405)
 
-    items = {"obc_board": COMPONENT_VOLUMES_CM3["obc_board"],
-             "harness_misc": COMPONENT_VOLUMES_CM3["harness_misc"]}
+    items: dict[str, float] = {
+        "obc_board": COMPONENT_VOLUMES_CM3["obc_board"],
+        "harness_misc": COMPONENT_VOLUMES_CM3["harness_misc"],
+    }
 
-    if enabled_subsystems.get("eps", True):
+    if enabled_subsystems.get("eps", False):
         items["eps_board"] = COMPONENT_VOLUMES_CM3["eps_board"]
         items["battery_pack"] = COMPONENT_VOLUMES_CM3["battery_pack"]
-    if enabled_subsystems.get("comm_uhf", True):
+    if enabled_subsystems.get("comm_uhf", False):
         items["comm_uhf"] = COMPONENT_VOLUMES_CM3["comm_uhf"]
     if enabled_subsystems.get("comm_sband", False):
         items["comm_sband"] = COMPONENT_VOLUMES_CM3["comm_sband"]
-    if enabled_subsystems.get("adcs", True):
+    if enabled_subsystems.get("adcs", False):
         items["adcs_unit"] = COMPONENT_VOLUMES_CM3["adcs_unit"]
-    if enabled_subsystems.get("gnss", True):
+    if enabled_subsystems.get("gnss", False):
         items["gnss_module"] = COMPONENT_VOLUMES_CM3["gnss_module"]
-    if enabled_subsystems.get("camera", True):
+    if enabled_subsystems.get("imu", False):
+        items["imu_module"] = COMPONENT_VOLUMES_CM3["imu_module"]
+    if enabled_subsystems.get("barometer", False):
+        items["barometer_module"] = COMPONENT_VOLUMES_CM3["barometer_module"]
+    if enabled_subsystems.get("camera", False):
         items["camera_module"] = COMPONENT_VOLUMES_CM3["camera_module"]
-    if enabled_subsystems.get("payload", True):
+    if enabled_subsystems.get("payload", False):
         items["payload_module"] = COMPONENT_VOLUMES_CM3["payload_module"]
+    if enabled_subsystems.get("descent_controller", False):
+        items["descent_controller_module"] = COMPONENT_VOLUMES_CM3["descent_controller_module"]
 
     total = sum(items.values())
-    util = total / available * 100
+    util = (total / available * 100) if available > 0 else 0.0
 
     return VolumeResult(
         total_cm3=total, available_cm3=available,

--- a/flight-software/core/__init__.py
+++ b/flight-software/core/__init__.py
@@ -1,0 +1,21 @@
+"""UniSat core framework — mission-agnostic architecture components.
+
+Provides the event bus, state machine, module registry, and mission type
+definitions that allow UniSat to support CubeSat, CanSat, rocket, HAB,
+drone, and other aerospace platforms from a single codebase.
+"""
+
+from core.mission_types import MissionType, PlatformCategory
+from core.event_bus import EventBus, Event
+from core.state_machine import StateMachine, MissionPhase
+from core.module_registry import ModuleRegistry
+
+__all__ = [
+    "MissionType",
+    "PlatformCategory",
+    "EventBus",
+    "Event",
+    "StateMachine",
+    "MissionPhase",
+    "ModuleRegistry",
+]

--- a/flight-software/core/event_bus.py
+++ b/flight-software/core/event_bus.py
@@ -1,0 +1,170 @@
+"""Event Bus — Async publish/subscribe for inter-module communication.
+
+Modules publish events (state changes, sensor triggers, errors) and other
+modules subscribe to those events. This decouples modules from each other
+and enables mission-phase-driven behaviour without hard dependencies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine
+
+logger = logging.getLogger("unisat.events")
+
+# Type alias for event handlers
+EventHandler = Callable[["Event"], Coroutine[Any, Any, None]]
+
+
+@dataclass
+class Event:
+    """A single event on the bus.
+
+    Attributes:
+        name: Dot-separated event name (e.g. "phase.ascent.enter").
+        data: Arbitrary payload dict.
+        source: Name of the module that published the event.
+        timestamp: Unix timestamp of event creation.
+        priority: Lower = higher priority (0 = critical).
+    """
+
+    name: str
+    data: dict[str, Any] = field(default_factory=dict)
+    source: str = ""
+    timestamp: float = field(default_factory=time.time)
+    priority: int = 5
+
+
+class EventBus:
+    """Async event bus with wildcard subscriptions and history.
+
+    Supports:
+    - Exact match: ``"phase.ascent.enter"``
+    - Wildcard: ``"phase.*"`` matches any event starting with ``phase.``
+    - Global: ``"*"`` matches everything
+    """
+
+    def __init__(self, history_size: int = 500) -> None:
+        self._handlers: dict[str, list[EventHandler]] = {}
+        self._history: list[Event] = []
+        self._history_size = history_size
+        self._event_counts: dict[str, int] = {}
+
+    def subscribe(self, pattern: str, handler: EventHandler) -> None:
+        """Subscribe a handler to events matching a pattern.
+
+        Args:
+            pattern: Event name or wildcard pattern.
+            handler: Async callable receiving an Event.
+        """
+        self._handlers.setdefault(pattern, []).append(handler)
+        logger.debug("Subscribed to '%s': %s", pattern, handler.__qualname__)
+
+    def unsubscribe(self, pattern: str, handler: EventHandler) -> None:
+        """Remove a specific handler from a pattern.
+
+        Args:
+            pattern: The pattern originally subscribed to.
+            handler: The handler to remove.
+        """
+        handlers = self._handlers.get(pattern, [])
+        if handler in handlers:
+            handlers.remove(handler)
+
+    async def publish(self, event: Event) -> int:
+        """Publish an event, calling all matching handlers.
+
+        Args:
+            event: The event to publish.
+
+        Returns:
+            Number of handlers invoked.
+        """
+        self._history.append(event)
+        if len(self._history) > self._history_size:
+            self._history = self._history[-self._history_size:]
+        self._event_counts[event.name] = self._event_counts.get(event.name, 0) + 1
+
+        handlers = self._matching_handlers(event.name)
+        count = 0
+        for handler in handlers:
+            try:
+                await handler(event)
+                count += 1
+            except Exception as exc:
+                logger.error(
+                    "Handler %s failed for event '%s': %s",
+                    handler.__qualname__, event.name, exc,
+                )
+        logger.debug("Published '%s' -> %d handlers", event.name, count)
+        return count
+
+    async def emit(self, name: str, data: dict[str, Any] | None = None,
+                   source: str = "", priority: int = 5) -> int:
+        """Convenience method to create and publish an event in one call.
+
+        Args:
+            name: Event name.
+            data: Optional payload dict.
+            source: Source module name.
+            priority: Event priority.
+
+        Returns:
+            Number of handlers invoked.
+        """
+        event = Event(name=name, data=data or {}, source=source, priority=priority)
+        return await self.publish(event)
+
+    def _matching_handlers(self, event_name: str) -> list[EventHandler]:
+        """Find all handlers whose pattern matches an event name."""
+        matched: list[EventHandler] = []
+        for pattern, handlers in self._handlers.items():
+            if self._pattern_matches(pattern, event_name):
+                matched.extend(handlers)
+        return matched
+
+    @staticmethod
+    def _pattern_matches(pattern: str, event_name: str) -> bool:
+        """Check if a subscription pattern matches an event name.
+
+        Rules:
+        - ``"*"`` matches everything.
+        - ``"foo.*"`` matches ``"foo.bar"``, ``"foo.bar.baz"``, etc.
+        - ``"foo.bar"`` matches only ``"foo.bar"`` exactly.
+        """
+        if pattern == "*":
+            return True
+        if pattern.endswith(".*"):
+            prefix = pattern[:-2]
+            return event_name == prefix or event_name.startswith(prefix + ".")
+        return pattern == event_name
+
+    def get_history(self, pattern: str | None = None, limit: int = 50) -> list[Event]:
+        """Return recent events, optionally filtered by pattern.
+
+        Args:
+            pattern: Optional filter pattern.
+            limit: Max number of events to return.
+
+        Returns:
+            List of matching events, newest first.
+        """
+        events = self._history
+        if pattern:
+            events = [e for e in events if self._pattern_matches(pattern, e.name)]
+        return list(reversed(events[-limit:]))
+
+    def get_stats(self) -> dict[str, Any]:
+        """Return event bus statistics."""
+        return {
+            "total_events": sum(self._event_counts.values()),
+            "unique_events": len(self._event_counts),
+            "subscriber_patterns": len(self._handlers),
+            "history_size": len(self._history),
+            "top_events": dict(
+                sorted(self._event_counts.items(), key=lambda x: -x[1])[:10]
+            ),
+        }

--- a/flight-software/core/mission_types.py
+++ b/flight-software/core/mission_types.py
@@ -1,0 +1,570 @@
+"""Mission type registry — defines supported platforms and competition profiles.
+
+Each MissionType describes the platform category, default mission phases,
+required/optional modules, and competition-specific constraints. The flight
+controller loads the appropriate profile from mission_config.json and uses
+it to configure the state machine, module registry, and power manager.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any
+
+
+class PlatformCategory(Enum):
+    """Top-level vehicle categories."""
+
+    CUBESAT = "cubesat"
+    CANSAT = "cansat"
+    SUBORBITAL_ROCKET = "suborbital_rocket"
+    HIGH_ALTITUDE_BALLOON = "high_altitude_balloon"
+    DRONE = "drone"
+    ROVER = "rover"
+    CUSTOM = "custom"
+
+
+class MissionType(Enum):
+    """Specific mission types with pre-built profiles."""
+
+    # CubeSat variants
+    CUBESAT_LEO = "cubesat_leo"
+    CUBESAT_SSO = "cubesat_sso"
+    CUBESAT_TECH_DEMO = "cubesat_tech_demo"
+
+    # CanSat variants
+    CANSAT_STANDARD = "cansat_standard"
+    CANSAT_ADVANCED = "cansat_advanced"
+
+    # Rocket variants
+    ROCKET_SOUNDING = "rocket_sounding"
+    ROCKET_COMPETITION = "rocket_competition"
+
+    # HAB variants
+    HAB_STANDARD = "hab_standard"
+    HAB_LONG_DURATION = "hab_long_duration"
+
+    # Drone variants
+    DRONE_SURVEY = "drone_survey"
+    DRONE_INSPECTION = "drone_inspection"
+
+    # Rover
+    ROVER_EXPLORATION = "rover_exploration"
+
+    # Custom (user-defined phases and modules)
+    CUSTOM = "custom"
+
+
+@dataclass
+class PhaseDefinition:
+    """Definition of a single mission phase.
+
+    Attributes:
+        name: Machine-readable phase name (e.g. "ascent").
+        display_name: Human-readable name (e.g. "Ascent Phase").
+        transitions_to: Phase names this phase can transition to.
+        timeout_s: Max duration before auto-transition (0 = no limit).
+        auto_next: Phase to auto-transition to on timeout (empty = stay).
+        required_modules: Modules that must be active in this phase.
+        disabled_modules: Modules to shut down in this phase.
+        entry_event: Event fired on phase entry.
+        exit_event: Event fired on phase exit.
+    """
+
+    name: str
+    display_name: str = ""
+    transitions_to: list[str] = field(default_factory=list)
+    timeout_s: float = 0.0
+    auto_next: str = ""
+    required_modules: list[str] = field(default_factory=list)
+    disabled_modules: list[str] = field(default_factory=list)
+    entry_event: str = ""
+    exit_event: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.display_name:
+            self.display_name = self.name.replace("_", " ").title()
+        if not self.entry_event:
+            self.entry_event = f"phase.{self.name}.enter"
+        if not self.exit_event:
+            self.exit_event = f"phase.{self.name}.exit"
+
+
+@dataclass
+class MissionProfile:
+    """Complete mission profile combining platform, phases, and modules.
+
+    Attributes:
+        mission_type: The mission type enum value.
+        platform: Platform category.
+        phases: Ordered list of phase definitions.
+        initial_phase: Name of the starting phase.
+        core_modules: Modules always loaded regardless of config.
+        optional_modules: Modules loaded only if enabled in config.
+        default_telemetry_hz: Default telemetry rate.
+        safe_mode_config: Override safe mode parameters per mission.
+        power_config: Override power thresholds per mission.
+        competition: Optional competition-specific metadata.
+    """
+
+    mission_type: MissionType
+    platform: PlatformCategory
+    phases: list[PhaseDefinition] = field(default_factory=list)
+    initial_phase: str = "startup"
+    core_modules: list[str] = field(default_factory=list)
+    optional_modules: list[str] = field(default_factory=list)
+    default_telemetry_hz: float = 1.0
+    safe_mode_config: dict[str, Any] = field(default_factory=dict)
+    power_config: dict[str, Any] = field(default_factory=dict)
+    competition: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Built-in mission profiles
+# ---------------------------------------------------------------------------
+
+def _cubesat_leo_profile() -> MissionProfile:
+    return MissionProfile(
+        mission_type=MissionType.CUBESAT_LEO,
+        platform=PlatformCategory.CUBESAT,
+        phases=[
+            PhaseDefinition(
+                name="startup",
+                transitions_to=["deployment", "safe_mode"],
+                timeout_s=300,
+                auto_next="deployment",
+            ),
+            PhaseDefinition(
+                name="deployment",
+                display_name="Antenna/Panel Deployment",
+                transitions_to=["detumbling", "safe_mode"],
+                timeout_s=1800,
+                auto_next="detumbling",
+                required_modules=["telemetry", "health", "eps"],
+            ),
+            PhaseDefinition(
+                name="detumbling",
+                transitions_to=["nominal", "safe_mode"],
+                timeout_s=3600,
+                auto_next="nominal",
+                required_modules=["telemetry", "health", "adcs", "eps"],
+            ),
+            PhaseDefinition(
+                name="nominal",
+                transitions_to=["science", "comm_window", "safe_mode", "low_power"],
+                required_modules=["telemetry", "health", "adcs", "eps", "comm", "scheduler"],
+            ),
+            PhaseDefinition(
+                name="science",
+                display_name="Science/Payload Operations",
+                transitions_to=["nominal", "safe_mode", "low_power"],
+                required_modules=["telemetry", "health", "payload", "data_logger"],
+            ),
+            PhaseDefinition(
+                name="comm_window",
+                display_name="Communication Window",
+                transitions_to=["nominal", "safe_mode"],
+                required_modules=["telemetry", "comm", "data_logger"],
+            ),
+            PhaseDefinition(
+                name="low_power",
+                transitions_to=["nominal", "safe_mode"],
+                required_modules=["telemetry", "health", "eps"],
+                disabled_modules=["camera", "payload", "comm_sband"],
+            ),
+            PhaseDefinition(
+                name="safe_mode",
+                transitions_to=["nominal", "low_power"],
+                required_modules=["telemetry", "health", "comm"],
+                disabled_modules=["camera", "payload", "comm_sband", "adcs"],
+            ),
+        ],
+        initial_phase="startup",
+        core_modules=["telemetry", "data_logger", "health", "scheduler", "eps"],
+        optional_modules=["comm", "adcs", "camera", "payload", "gnss", "orbit_predictor"],
+        default_telemetry_hz=1.0,
+        safe_mode_config={"comm_timeout_s": 86400, "beacon_interval_s": 30},
+        power_config={"soc_low": 30.0, "soc_critical": 15.0},
+    )
+
+
+def _cansat_standard_profile() -> MissionProfile:
+    return MissionProfile(
+        mission_type=MissionType.CANSAT_STANDARD,
+        platform=PlatformCategory.CANSAT,
+        phases=[
+            PhaseDefinition(
+                name="pre_launch",
+                display_name="Pre-Launch / Ground Checkout",
+                transitions_to=["launch_detect"],
+                required_modules=["telemetry", "health", "imu", "barometer"],
+            ),
+            PhaseDefinition(
+                name="launch_detect",
+                display_name="Launch Detection",
+                transitions_to=["ascent", "pre_launch"],
+                timeout_s=600,
+                auto_next="pre_launch",
+                required_modules=["telemetry", "imu", "barometer"],
+            ),
+            PhaseDefinition(
+                name="ascent",
+                transitions_to=["apogee"],
+                timeout_s=120,
+                auto_next="apogee",
+                required_modules=["telemetry", "imu", "barometer", "data_logger"],
+            ),
+            PhaseDefinition(
+                name="apogee",
+                display_name="Apogee / Ejection",
+                transitions_to=["descent"],
+                timeout_s=30,
+                auto_next="descent",
+                required_modules=["telemetry", "imu", "barometer", "descent_controller"],
+            ),
+            PhaseDefinition(
+                name="descent",
+                display_name="Parachute Descent",
+                transitions_to=["landed"],
+                timeout_s=300,
+                auto_next="landed",
+                required_modules=["telemetry", "imu", "barometer", "descent_controller",
+                                  "data_logger", "payload"],
+            ),
+            PhaseDefinition(
+                name="landed",
+                transitions_to=[],
+                timeout_s=3600,
+                required_modules=["telemetry", "comm"],
+                disabled_modules=["descent_controller"],
+            ),
+        ],
+        initial_phase="pre_launch",
+        core_modules=["telemetry", "data_logger", "health", "imu", "barometer"],
+        optional_modules=["comm", "camera", "payload", "descent_controller", "gnss"],
+        default_telemetry_hz=10.0,
+        safe_mode_config={"comm_timeout_s": 300, "beacon_interval_s": 5},
+        power_config={"soc_low": 20.0, "soc_critical": 10.0},
+        competition={
+            "type": "cansat",
+            "descent_rate_range_m_s": [6.0, 11.0],
+            "max_landing_velocity_m_s": 12.0,
+            "min_telemetry_samples": 100,
+        },
+    )
+
+
+def _rocket_competition_profile() -> MissionProfile:
+    return MissionProfile(
+        mission_type=MissionType.ROCKET_COMPETITION,
+        platform=PlatformCategory.SUBORBITAL_ROCKET,
+        phases=[
+            PhaseDefinition(
+                name="ground_checkout",
+                display_name="Ground Checkout",
+                transitions_to=["armed"],
+                required_modules=["telemetry", "health", "imu"],
+            ),
+            PhaseDefinition(
+                name="armed",
+                transitions_to=["boost", "ground_checkout"],
+                timeout_s=600,
+                auto_next="ground_checkout",
+                required_modules=["telemetry", "imu", "barometer"],
+            ),
+            PhaseDefinition(
+                name="boost",
+                display_name="Boost Phase",
+                transitions_to=["coast"],
+                timeout_s=30,
+                auto_next="coast",
+                required_modules=["telemetry", "imu", "barometer", "data_logger"],
+            ),
+            PhaseDefinition(
+                name="coast",
+                display_name="Coast Phase",
+                transitions_to=["apogee"],
+                timeout_s=60,
+                auto_next="apogee",
+                required_modules=["telemetry", "imu", "barometer", "data_logger"],
+            ),
+            PhaseDefinition(
+                name="apogee",
+                transitions_to=["drogue_descent"],
+                timeout_s=10,
+                auto_next="drogue_descent",
+                required_modules=["telemetry", "imu", "barometer"],
+            ),
+            PhaseDefinition(
+                name="drogue_descent",
+                display_name="Drogue Descent",
+                transitions_to=["main_descent"],
+                required_modules=["telemetry", "imu", "barometer", "data_logger"],
+            ),
+            PhaseDefinition(
+                name="main_descent",
+                display_name="Main Chute Descent",
+                transitions_to=["landed"],
+                required_modules=["telemetry", "imu", "barometer", "data_logger"],
+            ),
+            PhaseDefinition(
+                name="landed",
+                transitions_to=[],
+                required_modules=["telemetry", "comm"],
+            ),
+        ],
+        initial_phase="ground_checkout",
+        core_modules=["telemetry", "data_logger", "health", "imu", "barometer"],
+        optional_modules=["comm", "payload", "gnss", "camera"],
+        default_telemetry_hz=20.0,
+        safe_mode_config={"comm_timeout_s": 600, "beacon_interval_s": 10},
+        power_config={"soc_low": 20.0, "soc_critical": 10.0},
+        competition={
+            "type": "rocket",
+            "target_altitude_m": 3048,
+            "max_acceleration_g": 20,
+        },
+    )
+
+
+def _hab_standard_profile() -> MissionProfile:
+    return MissionProfile(
+        mission_type=MissionType.HAB_STANDARD,
+        platform=PlatformCategory.HIGH_ALTITUDE_BALLOON,
+        phases=[
+            PhaseDefinition(
+                name="ground_setup",
+                display_name="Ground Setup / Inflation",
+                transitions_to=["ascent"],
+                required_modules=["telemetry", "health", "barometer"],
+            ),
+            PhaseDefinition(
+                name="ascent",
+                transitions_to=["float", "burst"],
+                timeout_s=10800,
+                auto_next="float",
+                required_modules=["telemetry", "health", "barometer", "gnss",
+                                  "data_logger", "payload", "camera"],
+            ),
+            PhaseDefinition(
+                name="float",
+                display_name="Float Altitude",
+                transitions_to=["burst"],
+                timeout_s=7200,
+                auto_next="burst",
+                required_modules=["telemetry", "health", "barometer", "gnss",
+                                  "data_logger", "payload", "camera"],
+            ),
+            PhaseDefinition(
+                name="burst",
+                display_name="Balloon Burst",
+                transitions_to=["descent"],
+                timeout_s=10,
+                auto_next="descent",
+                required_modules=["telemetry", "barometer", "gnss"],
+            ),
+            PhaseDefinition(
+                name="descent",
+                transitions_to=["landed"],
+                timeout_s=5400,
+                auto_next="landed",
+                required_modules=["telemetry", "barometer", "gnss", "comm", "data_logger"],
+            ),
+            PhaseDefinition(
+                name="landed",
+                transitions_to=[],
+                required_modules=["telemetry", "comm", "gnss"],
+            ),
+        ],
+        initial_phase="ground_setup",
+        core_modules=["telemetry", "data_logger", "health", "barometer", "gnss"],
+        optional_modules=["comm", "camera", "payload", "imu"],
+        default_telemetry_hz=0.5,
+        safe_mode_config={"comm_timeout_s": 7200, "beacon_interval_s": 60},
+        power_config={"soc_low": 25.0, "soc_critical": 10.0},
+    )
+
+
+def _drone_survey_profile() -> MissionProfile:
+    return MissionProfile(
+        mission_type=MissionType.DRONE_SURVEY,
+        platform=PlatformCategory.DRONE,
+        phases=[
+            PhaseDefinition(
+                name="preflight",
+                display_name="Pre-Flight Check",
+                transitions_to=["armed"],
+                required_modules=["telemetry", "health", "imu", "gnss"],
+            ),
+            PhaseDefinition(
+                name="armed",
+                transitions_to=["takeoff", "preflight"],
+                timeout_s=120,
+                auto_next="preflight",
+                required_modules=["telemetry", "health", "imu", "gnss"],
+            ),
+            PhaseDefinition(
+                name="takeoff",
+                transitions_to=["mission_flight"],
+                timeout_s=60,
+                auto_next="mission_flight",
+                required_modules=["telemetry", "imu", "gnss", "barometer"],
+            ),
+            PhaseDefinition(
+                name="mission_flight",
+                display_name="Mission Flight",
+                transitions_to=["return_to_home", "landing", "emergency"],
+                required_modules=["telemetry", "imu", "gnss", "camera",
+                                  "payload", "data_logger"],
+            ),
+            PhaseDefinition(
+                name="return_to_home",
+                display_name="Return to Home",
+                transitions_to=["landing", "emergency"],
+                required_modules=["telemetry", "imu", "gnss"],
+                disabled_modules=["camera", "payload"],
+            ),
+            PhaseDefinition(
+                name="landing",
+                transitions_to=["landed"],
+                timeout_s=120,
+                auto_next="landed",
+                required_modules=["telemetry", "imu", "gnss", "barometer"],
+            ),
+            PhaseDefinition(
+                name="landed",
+                transitions_to=["preflight"],
+                required_modules=["telemetry", "health"],
+            ),
+            PhaseDefinition(
+                name="emergency",
+                display_name="Emergency Landing",
+                transitions_to=["landed"],
+                required_modules=["telemetry", "imu", "gnss"],
+                disabled_modules=["camera", "payload"],
+            ),
+        ],
+        initial_phase="preflight",
+        core_modules=["telemetry", "data_logger", "health", "imu", "gnss", "barometer"],
+        optional_modules=["comm", "camera", "payload"],
+        default_telemetry_hz=10.0,
+        safe_mode_config={"comm_timeout_s": 300, "beacon_interval_s": 5},
+        power_config={"soc_low": 25.0, "soc_critical": 15.0},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Profile registry
+# ---------------------------------------------------------------------------
+
+_PROFILES: dict[MissionType, MissionProfile] = {}
+
+
+def _register_builtins() -> None:
+    """Register all built-in mission profiles."""
+    for factory in [
+        _cubesat_leo_profile,
+        _cansat_standard_profile,
+        _rocket_competition_profile,
+        _hab_standard_profile,
+        _drone_survey_profile,
+    ]:
+        profile = factory()
+        _PROFILES[profile.mission_type] = profile
+
+
+_register_builtins()
+
+
+def get_mission_profile(mission_type: MissionType | str) -> MissionProfile:
+    """Look up a built-in mission profile by type.
+
+    Args:
+        mission_type: MissionType enum or its string value.
+
+    Returns:
+        The matching MissionProfile.
+
+    Raises:
+        KeyError: If no profile matches the given type.
+    """
+    if isinstance(mission_type, str):
+        try:
+            mission_type = MissionType(mission_type)
+        except ValueError as exc:
+            raise KeyError(f"Unknown mission type: {mission_type}") from exc
+    if mission_type not in _PROFILES:
+        raise KeyError(f"No built-in profile for mission type: {mission_type.value}")
+    return _PROFILES[mission_type]
+
+
+def register_mission_profile(profile: MissionProfile) -> None:
+    """Register a custom mission profile.
+
+    Args:
+        profile: The profile to register (overrides existing if same type).
+    """
+    _PROFILES[profile.mission_type] = profile
+
+
+def list_mission_types() -> list[str]:
+    """Return list of all registered mission type names."""
+    return [mt.value for mt in _PROFILES]
+
+
+def build_profile_from_config(config: dict) -> MissionProfile:
+    """Build a MissionProfile from a mission_config.json dict.
+
+    If config contains a known ``mission_type``, the built-in profile is
+    loaded and then overridden by any explicit config values.  If the type
+    is ``custom``, the profile is built entirely from config.
+
+    Args:
+        config: Parsed mission_config.json content.
+
+    Returns:
+        A fully resolved MissionProfile.
+    """
+    mission_cfg = config.get("mission", {})
+    mission_type_str = mission_cfg.get("mission_type", "cubesat_leo")
+
+    try:
+        base = copy.deepcopy(get_mission_profile(mission_type_str))
+    except (KeyError, ValueError):
+        base = MissionProfile(
+            mission_type=MissionType.CUSTOM,
+            platform=PlatformCategory(mission_cfg.get("platform", "custom")),
+        )
+
+    # Override phases from config if provided
+    phases_cfg = mission_cfg.get("phases")
+    if phases_cfg:
+        base.phases = [
+            PhaseDefinition(**p) for p in phases_cfg
+        ]
+        if mission_cfg.get("initial_phase"):
+            base.initial_phase = mission_cfg["initial_phase"]
+
+    # Override module lists
+    if "core_modules" in mission_cfg:
+        base.core_modules = mission_cfg["core_modules"]
+    if "optional_modules" in mission_cfg:
+        base.optional_modules = mission_cfg["optional_modules"]
+
+    # Override telemetry rate
+    if "telemetry_hz" in mission_cfg:
+        base.default_telemetry_hz = mission_cfg["telemetry_hz"]
+
+    # Override safe mode / power
+    if "safe_mode" in config:
+        base.safe_mode_config.update(config["safe_mode"])
+    if "power" in config:
+        base.power_config.update(config["power"])
+
+    # Competition metadata
+    if "competition" in mission_cfg:
+        base.competition.update(mission_cfg["competition"])
+
+    return base

--- a/flight-software/core/module_registry.py
+++ b/flight-software/core/module_registry.py
@@ -1,0 +1,226 @@
+"""Module Registry — Dynamic module loading with config injection.
+
+Replaces the old hardcoded MODULE_MAP. Discovers and loads modules by name,
+passes per-module config from mission_config.json, and manages lifecycle
+(initialize -> start -> stop) for all registered modules.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any
+
+from modules import BaseModule, ModuleStatus
+from core.event_bus import EventBus
+
+logger = logging.getLogger("unisat.registry")
+
+# Maps short module names to their importable module paths and class names.
+# New modules just add an entry here — no other code changes needed.
+DEFAULT_MODULE_MAP: dict[str, tuple[str, str]] = {
+    # Core modules
+    "telemetry": ("modules.telemetry_manager", "TelemetryManager"),
+    "data_logger": ("modules.data_logger", "DataLogger"),
+    "health": ("modules.health_monitor", "HealthMonitor"),
+    "scheduler": ("modules.scheduler", "TaskScheduler"),
+
+    # Communication
+    "comm": ("modules.communication", "CommunicationManager"),
+
+    # Navigation & ADCS
+    "orbit_predictor": ("modules.orbit_predictor", "OrbitPredictor"),
+
+    # Imaging
+    "camera": ("modules.camera_handler", "CameraHandler"),
+    "image_processor": ("modules.image_processor", "ImageProcessor"),
+
+    # Power & Safety
+    "power_manager": ("modules.power_manager", "PowerManager"),
+    "safe_mode": ("modules.safe_mode", "SafeModeHandler"),
+
+    # Payload
+    "payload": ("modules.payload_interface", "RadiationPayload"),
+
+    # --- New modules for multi-mission support ---
+    "imu": ("modules.imu_sensor", "IMUSensor"),
+    "barometer": ("modules.barometric_altimeter", "BarometricAltimeter"),
+    "descent_controller": ("modules.descent_controller", "DescentController"),
+}
+
+
+class ModuleRegistry:
+    """Manages dynamic loading, configuration, and lifecycle of flight modules.
+
+    Attributes:
+        modules: Dict of loaded module instances by name.
+        event_bus: Shared event bus for inter-module communication.
+    """
+
+    def __init__(self, event_bus: EventBus,
+                 module_map: dict[str, tuple[str, str]] | None = None) -> None:
+        """Initialize the registry.
+
+        Args:
+            event_bus: The shared event bus instance.
+            module_map: Optional override for the module mapping.
+        """
+        self.event_bus = event_bus
+        self._module_map: dict[str, tuple[str, str]] = dict(
+            module_map or DEFAULT_MODULE_MAP
+        )
+        self.modules: dict[str, BaseModule] = {}
+        self._load_errors: dict[str, str] = {}
+
+    def register_module(self, name: str, module_path: str, class_name: str) -> None:
+        """Register a new module type.
+
+        Args:
+            name: Short name used in config (e.g. "imu").
+            module_path: Python module path (e.g. "modules.imu_sensor").
+            class_name: Class name to instantiate.
+        """
+        self._module_map[name] = (module_path, class_name)
+        logger.info("Registered module type: %s -> %s.%s", name, module_path, class_name)
+
+    def load_module(self, name: str, config: dict[str, Any] | None = None) -> BaseModule | None:
+        """Load and instantiate a single module.
+
+        Args:
+            name: Module name (must be in the module map).
+            config: Per-module configuration dict.
+
+        Returns:
+            The instantiated module, or None on failure.
+        """
+        if name in self.modules:
+            logger.debug("Module '%s' already loaded", name)
+            return self.modules[name]
+
+        mapping = self._module_map.get(name)
+        if not mapping:
+            self._load_errors[name] = f"Unknown module: {name}"
+            logger.warning("No mapping for module: %s", name)
+            return None
+
+        module_path, class_name = mapping
+        try:
+            mod = importlib.import_module(module_path)
+            cls = getattr(mod, class_name)
+            instance = cls(config=config or {})
+            self.modules[name] = instance
+            logger.info("Loaded module: %s (%s.%s)", name, module_path, class_name)
+            return instance
+        except ImportError as exc:
+            self._load_errors[name] = f"Import error: {exc}"
+            logger.warning("Failed to import %s: %s", module_path, exc)
+        except AttributeError as exc:
+            self._load_errors[name] = f"Class not found: {exc}"
+            logger.warning("Class %s not found in %s: %s", class_name, module_path, exc)
+        except TypeError as exc:
+            # Module constructor doesn't accept config — try without
+            try:
+                mod = importlib.import_module(module_path)
+                cls = getattr(mod, class_name)
+                instance = cls()
+                self.modules[name] = instance
+                logger.info("Loaded module (no-config): %s", name)
+                return instance
+            except Exception as inner_exc:
+                self._load_errors[name] = f"Instantiation error: {inner_exc}"
+                logger.warning("Failed to instantiate %s: %s", name, inner_exc)
+        except Exception as exc:
+            self._load_errors[name] = f"Unexpected error: {exc}"
+            logger.error("Unexpected error loading %s: %s", name, exc)
+
+        return None
+
+    def load_modules_from_config(self, config: dict,
+                                 core_modules: list[str],
+                                 optional_modules: list[str]) -> dict[str, BaseModule]:
+        """Load all modules specified by the mission profile and config.
+
+        Core modules are always loaded. Optional modules are loaded only
+        if their subsystem is enabled in ``config["subsystems"]``.
+
+        Args:
+            config: Full mission_config.json content.
+            core_modules: Module names to always load.
+            optional_modules: Module names to load if enabled.
+
+        Returns:
+            Dict of successfully loaded modules.
+        """
+        subsystems_cfg = config.get("subsystems", {})
+
+        # Load core modules (always)
+        for name in core_modules:
+            module_cfg = subsystems_cfg.get(name, {})
+            self.load_module(name, module_cfg)
+
+        # Load optional modules (only if enabled)
+        for name in optional_modules:
+            sub_cfg = subsystems_cfg.get(name, {})
+            if sub_cfg.get("enabled", False):
+                self.load_module(name, sub_cfg)
+
+        logger.info(
+            "Module loading complete: %d loaded, %d failed",
+            len(self.modules), len(self._load_errors),
+        )
+        return self.modules
+
+    async def initialize_all(self) -> dict[str, bool]:
+        """Initialize all loaded modules.
+
+        Returns:
+            Dict mapping module name to initialization success.
+        """
+        results: dict[str, bool] = {}
+        for name, module in self.modules.items():
+            try:
+                ok = await module.initialize()
+                results[name] = ok
+                if ok:
+                    logger.info("Initialized: %s", name)
+                else:
+                    logger.warning("Init returned False: %s", name)
+            except Exception as exc:
+                results[name] = False
+                logger.error("Init failed for %s: %s", name, exc)
+        return results
+
+    async def start_all(self) -> None:
+        """Start all initialized modules."""
+        for name, module in self.modules.items():
+            if module.status == ModuleStatus.READY:
+                try:
+                    await module.start()
+                except Exception as exc:
+                    logger.error("Start failed for %s: %s", name, exc)
+
+    async def stop_all(self) -> None:
+        """Stop all running modules."""
+        for name, module in self.modules.items():
+            if module.status in (ModuleStatus.RUNNING, ModuleStatus.READY):
+                try:
+                    await module.stop()
+                except Exception as exc:
+                    logger.error("Stop failed for %s: %s", name, exc)
+
+    def get_module(self, name: str) -> BaseModule | None:
+        """Get a loaded module by name."""
+        return self.modules.get(name)
+
+    def get_status_report(self) -> dict[str, Any]:
+        """Return status of all modules and load errors."""
+        return {
+            "loaded": {
+                name: {
+                    "status": mod.status.name,
+                    "type": type(mod).__name__,
+                }
+                for name, mod in self.modules.items()
+            },
+            "errors": dict(self._load_errors),
+        }

--- a/flight-software/core/state_machine.py
+++ b/flight-software/core/state_machine.py
@@ -1,0 +1,211 @@
+"""Configurable State Machine — Mission-phase management.
+
+Unlike the old hardcoded 4-state enum, this state machine loads phase
+definitions from a MissionProfile and supports:
+- Validated transitions (only allowed next-phases)
+- Timeout-based auto-transitions
+- Event-driven transitions via the EventBus
+- Per-phase module enable/disable
+- Transition guards (async callables that can veto a transition)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine
+
+from core.mission_types import MissionProfile, PhaseDefinition
+
+logger = logging.getLogger("unisat.state_machine")
+
+# Transition guard: async callable returning True to allow transition
+TransitionGuard = Callable[[str, str], Coroutine[Any, Any, bool]]
+
+
+@dataclass
+class MissionPhase:
+    """Runtime state for the current mission phase.
+
+    Attributes:
+        definition: The phase definition from the mission profile.
+        entered_at: Unix timestamp when this phase was entered.
+        transition_count: How many times we've entered this phase.
+    """
+
+    definition: PhaseDefinition
+    entered_at: float = field(default_factory=time.time)
+    transition_count: int = 0
+
+
+@dataclass
+class TransitionRecord:
+    """Record of a state transition for logging/telemetry."""
+
+    from_phase: str
+    to_phase: str
+    timestamp: float
+    reason: str = ""
+
+
+class StateMachine:
+    """Configurable mission state machine.
+
+    Loads phases from a MissionProfile, validates transitions, and emits
+    events on the EventBus when phases change.
+
+    Attributes:
+        current: The current MissionPhase.
+        profile: The active mission profile.
+        history: List of transition records.
+    """
+
+    def __init__(self, profile: MissionProfile) -> None:
+        """Initialize from a mission profile.
+
+        Args:
+            profile: The mission profile defining phases and transitions.
+        """
+        self.profile = profile
+        self._phases: dict[str, PhaseDefinition] = {
+            p.name: p for p in profile.phases
+        }
+        self._guards: list[TransitionGuard] = []
+        self.history: list[TransitionRecord] = []
+
+        initial = self._phases.get(profile.initial_phase)
+        if not initial:
+            raise ValueError(
+                f"Initial phase '{profile.initial_phase}' not found in profile. "
+                f"Available: {list(self._phases.keys())}"
+            )
+        self.current = MissionPhase(definition=initial)
+        logger.info("State machine initialized, phase: %s", self.current.definition.name)
+
+    @property
+    def phase_name(self) -> str:
+        """Current phase name."""
+        return self.current.definition.name
+
+    @property
+    def phase_display(self) -> str:
+        """Current phase display name."""
+        return self.current.definition.display_name
+
+    def add_guard(self, guard: TransitionGuard) -> None:
+        """Register a transition guard.
+
+        Args:
+            guard: Async callable(from_phase, to_phase) -> bool.
+        """
+        self._guards.append(guard)
+
+    async def transition_to(self, target_phase: str, reason: str = "") -> bool:
+        """Attempt to transition to a new phase.
+
+        Args:
+            target_phase: Name of the target phase.
+            reason: Human-readable reason for the transition.
+
+        Returns:
+            True if the transition succeeded.
+        """
+        current_name = self.current.definition.name
+
+        if target_phase == current_name:
+            return True
+
+        if target_phase not in self._phases:
+            logger.error("Unknown phase: '%s'", target_phase)
+            return False
+
+        allowed = self.current.definition.transitions_to
+        if allowed and target_phase not in allowed:
+            logger.warning(
+                "Transition %s -> %s not allowed (allowed: %s)",
+                current_name, target_phase, allowed,
+            )
+            return False
+
+        # Run guards
+        for guard in self._guards:
+            try:
+                ok = await guard(current_name, target_phase)
+                if not ok:
+                    logger.info("Guard vetoed transition %s -> %s", current_name, target_phase)
+                    return False
+            except Exception as exc:
+                logger.error("Guard error: %s", exc)
+                return False
+
+        # Perform transition
+        target_def = self._phases[target_phase]
+        record = TransitionRecord(
+            from_phase=current_name,
+            to_phase=target_phase,
+            timestamp=time.time(),
+            reason=reason,
+        )
+        self.history.append(record)
+
+        old_phase = self.current
+        self.current = MissionPhase(
+            definition=target_def,
+            transition_count=old_phase.transition_count + 1,
+        )
+
+        logger.info(
+            "Phase transition: %s -> %s (reason: %s)",
+            current_name, target_phase, reason or "manual",
+        )
+        return True
+
+    def check_timeout(self) -> str | None:
+        """Check if the current phase has timed out.
+
+        Returns:
+            The auto-next phase name if timed out, None otherwise.
+        """
+        defn = self.current.definition
+        if defn.timeout_s <= 0 or not defn.auto_next:
+            return None
+        elapsed = time.time() - self.current.entered_at
+        if elapsed >= defn.timeout_s:
+            return defn.auto_next
+        return None
+
+    def get_elapsed(self) -> float:
+        """Seconds spent in the current phase."""
+        return time.time() - self.current.entered_at
+
+    def get_available_transitions(self) -> list[str]:
+        """Return list of phases the current phase can transition to."""
+        return list(self.current.definition.transitions_to)
+
+    def get_phase_info(self) -> dict[str, Any]:
+        """Return a telemetry-friendly dict of current state."""
+        return {
+            "phase": self.current.definition.name,
+            "display_name": self.current.definition.display_name,
+            "elapsed_s": round(self.get_elapsed(), 1),
+            "transitions_to": self.current.definition.transitions_to,
+            "timeout_s": self.current.definition.timeout_s,
+            "auto_next": self.current.definition.auto_next,
+            "transition_count": self.current.transition_count,
+            "required_modules": self.current.definition.required_modules,
+            "disabled_modules": self.current.definition.disabled_modules,
+        }
+
+    def list_phases(self) -> list[dict[str, Any]]:
+        """Return summary of all defined phases."""
+        return [
+            {
+                "name": p.name,
+                "display_name": p.display_name,
+                "transitions_to": p.transitions_to,
+                "timeout_s": p.timeout_s,
+            }
+            for p in self.profile.phases
+        ]

--- a/flight-software/flight_controller.py
+++ b/flight-software/flight_controller.py
@@ -1,44 +1,49 @@
 """
-UniSat Flight Controller — Main async mission control.
+UniSat Flight Controller — Multi-mission async mission control.
 
-Manages all satellite subsystems through dynamic module loading,
-async task scheduling, and state machine transitions.
+Manages all subsystems through dynamic module loading, configurable state
+machine, event-driven architecture, and async task scheduling. Supports
+CubeSat, CanSat, rocket, HAB, drone, and custom mission profiles.
 """
 
 import asyncio
 import json
 import logging
-import importlib
-from enum import Enum
 from pathlib import Path
 from typing import Any
+
+from core.event_bus import EventBus, Event
+from core.state_machine import StateMachine
+from core.module_registry import ModuleRegistry
+from core.mission_types import (
+    MissionProfile,
+    build_profile_from_config,
+)
 
 logger = logging.getLogger("unisat.flight")
 
 
-class SatelliteState(Enum):
-    """Satellite operational states."""
-    STARTUP = "startup"
-    NOMINAL = "nominal"
-    SAFE_MODE = "safe_mode"
-    LOW_POWER = "low_power"
-
-
 class FlightController:
-    """Main flight controller for UniSat CubeSat."""
+    """Main flight controller for UniSat multi-mission platform.
 
-    MODULE_MAP = {
-        "comm": "modules.communication",
-        "camera": "modules.camera_handler",
-        "adcs": "modules.orbit_predictor",
-        "gnss": "modules.orbit_predictor",
-        "payload": "modules.payload_interface",
-    }
+    Orchestrates the event bus, state machine, module registry, and async
+    task loops. Configuration is loaded from mission_config.json and the
+    appropriate mission profile is selected automatically.
+
+    Attributes:
+        config: Raw mission configuration dict.
+        profile: Resolved mission profile with phases and module lists.
+        event_bus: Shared event bus for inter-module communication.
+        state_machine: Configurable phase-based state machine.
+        registry: Dynamic module registry.
+    """
 
     def __init__(self, config_path: str = "mission_config.json") -> None:
         self.config = self._load_config(config_path)
-        self.state = SatelliteState.STARTUP
-        self.modules: dict[str, Any] = {}
+        self.profile: MissionProfile = build_profile_from_config(self.config)
+        self.event_bus = EventBus()
+        self.state_machine = StateMachine(self.profile)
+        self.registry = ModuleRegistry(self.event_bus)
         self.command_queue: asyncio.Queue[dict] = asyncio.Queue()
         self._running = False
         self._setup_logging()
@@ -49,6 +54,8 @@ class FlightController:
         config_path = Path(path)
         if not config_path.exists():
             config_path = Path(__file__).parent.parent / path
+        if not config_path.exists():
+            config_path = Path(__file__).parent / path
         with open(config_path, "r", encoding="utf-8") as f:
             return json.load(f)
 
@@ -60,50 +67,104 @@ class FlightController:
         )
         handler.setFormatter(formatter)
         root = logging.getLogger("unisat")
-        root.addHandler(handler)
+        if not root.handlers:
+            root.addHandler(handler)
         root.setLevel(logging.DEBUG)
 
     async def initialize(self) -> None:
-        """Initialize all enabled subsystems from config."""
+        """Initialize all subsystems based on mission profile and config."""
         mission = self.config.get("mission", {})
-        logger.info("Initializing %s v%s", mission.get("name"), mission.get("version"))
+        logger.info(
+            "Initializing %s v%s [%s / %s]",
+            mission.get("name", "UniSat"),
+            mission.get("version", "?"),
+            self.profile.mission_type.value,
+            self.profile.platform.value,
+        )
 
-        from modules.telemetry_manager import TelemetryManager
-        from modules.data_logger import DataLogger
-        from modules.health_monitor import HealthMonitor
-        from modules.scheduler import TaskScheduler
+        # Register event handlers for state transitions
+        self.event_bus.subscribe("phase.*", self._on_phase_event)
+        self.event_bus.subscribe("module.*", self._on_module_event)
 
-        self.modules["telemetry"] = TelemetryManager()
-        self.modules["data_logger"] = DataLogger()
-        self.modules["health"] = HealthMonitor()
-        self.modules["scheduler"] = TaskScheduler()
+        # Load modules from profile + config
+        self.registry.load_modules_from_config(
+            self.config,
+            core_modules=self.profile.core_modules,
+            optional_modules=self.profile.optional_modules,
+        )
 
-        subsystems = self.config.get("subsystems", {})
-        for name, cfg in subsystems.items():
-            if cfg.get("enabled", False) and name in self.MODULE_MAP:
-                try:
-                    importlib.import_module(self.MODULE_MAP[name])
-                    logger.info("Loaded module: %s", name)
-                except ImportError as exc:
-                    logger.warning("Failed to load %s: %s", name, exc)
+        # Initialize all loaded modules
+        results = await self.registry.initialize_all()
+        failed = [name for name, ok in results.items() if not ok]
+        if failed:
+            logger.warning("Modules failed to initialize: %s", failed)
 
-        self.state = SatelliteState.NOMINAL
-        logger.info("All subsystems initialized — state: NOMINAL")
+        # Start all initialized modules
+        await self.registry.start_all()
+
+        # Emit startup event
+        await self.event_bus.emit(
+            "system.initialized",
+            data={
+                "mission_type": self.profile.mission_type.value,
+                "platform": self.profile.platform.value,
+                "modules_loaded": list(self.registry.modules.keys()),
+                "initial_phase": self.state_machine.phase_name,
+            },
+            source="flight_controller",
+        )
+
+        logger.info(
+            "Initialization complete — %d modules loaded, phase: %s",
+            len(self.registry.modules),
+            self.state_machine.phase_name,
+        )
+
+    async def _on_phase_event(self, event: Event) -> None:
+        """Handle phase transition events."""
+        logger.debug("Phase event: %s -> %s", event.name, event.data)
+
+    async def _on_module_event(self, event: Event) -> None:
+        """Handle module lifecycle events."""
+        logger.debug("Module event: %s -> %s", event.name, event.data)
+
+    # ------------------------------------------------------------------
+    # Main loops
+    # ------------------------------------------------------------------
 
     async def telemetry_loop(self) -> None:
-        """Collect and store telemetry at 1 Hz."""
-        tlm = self.modules.get("telemetry")
-        db = self.modules.get("data_logger")
+        """Collect and store telemetry at the mission-configured rate."""
+        interval = 1.0 / max(self.profile.default_telemetry_hz, 0.1)
+        tlm = self.registry.get_module("telemetry")
+        db = self.registry.get_module("data_logger")
+
         while self._running:
             try:
-                health = self.modules["health"].get_report()
-                if tlm:
-                    packet = tlm.build_housekeeping_packet(health)
+                # Build telemetry from all available sources
+                health_mod = self.registry.get_module("health")
+                if health_mod and tlm:
+                    report = await health_mod.check_health()
+                    packet = tlm.build_packet(
+                        tlm.APID.HOUSEKEEPING if hasattr(tlm, "APID") else 0x01,
+                        tlm.pack_housekeeping(
+                            battery_v=3.7,
+                            battery_soc=0.85,
+                            cpu_temp=report.cpu_temp_c,
+                            solar_current_ma=0.0,
+                            uptime_s=int(report.uptime_s),
+                        ),
+                    )
                     if db:
-                        db.store_telemetry(packet)
+                        await db.log_telemetry(
+                            timestamp=report.timestamp,
+                            apid=0x01,
+                            sequence_count=0,
+                            mission_time=report.uptime_s,
+                            payload=packet,
+                        )
             except Exception as exc:
                 logger.error("Telemetry error: %s", exc)
-            await asyncio.sleep(1.0)
+            await asyncio.sleep(interval)
 
     async def command_loop(self) -> None:
         """Process incoming telecommands."""
@@ -117,43 +178,117 @@ class FlightController:
             except Exception as exc:
                 logger.error("Command error: %s", exc)
 
+    async def state_machine_loop(self) -> None:
+        """Monitor state machine timeouts and trigger auto-transitions."""
+        while self._running:
+            try:
+                # Check for phase timeout
+                auto_next = self.state_machine.check_timeout()
+                if auto_next:
+                    old = self.state_machine.phase_name
+                    ok = await self.state_machine.transition_to(
+                        auto_next, reason="timeout"
+                    )
+                    if ok:
+                        await self.event_bus.emit(
+                            self.state_machine.current.definition.entry_event,
+                            data={"from": old, "to": auto_next, "reason": "timeout"},
+                            source="state_machine",
+                        )
+            except Exception as exc:
+                logger.error("State machine error: %s", exc)
+            await asyncio.sleep(1.0)
+
+    async def scheduler_loop(self) -> None:
+        """Run scheduled tasks via the task scheduler."""
+        scheduler = self.registry.get_module("scheduler")
+        if not scheduler:
+            logger.warning("No scheduler module loaded, skipping scheduler loop")
+            return
+
+        while self._running:
+            try:
+                executed = await scheduler.tick()
+                if executed:
+                    logger.debug("Scheduler executed %d tasks", executed)
+            except Exception as exc:
+                logger.error("Scheduler error: %s", exc)
+            await asyncio.sleep(1.0)
+
     async def _execute_command(self, cmd: dict) -> None:
         """Execute a validated telecommand."""
         cmd_type = cmd.get("type", "")
-        if cmd_type == "set_mode":
+
+        if cmd_type == "set_phase":
+            target = cmd.get("phase", "")
+            reason = cmd.get("reason", "telecommand")
+            ok = await self.state_machine.transition_to(target, reason=reason)
+            if ok:
+                await self.event_bus.emit(
+                    f"phase.{target}.enter",
+                    data={"reason": reason},
+                    source="command",
+                )
+
+        elif cmd_type == "set_mode":
+            # Legacy compatibility
             mode = cmd.get("mode", "nominal")
-            self.state = SatelliteState(mode)
-            logger.info("Mode changed to %s", self.state.value)
+            await self.state_machine.transition_to(mode, reason="legacy_command")
+
         elif cmd_type == "capture_image":
-            cam = self.modules.get("camera")
-            if cam:
+            cam = self.registry.get_module("camera")
+            if cam and hasattr(cam, "capture"):
                 cam.capture()
+
         elif cmd_type == "reboot":
             logger.warning("Reboot commanded")
             self._running = False
 
-    async def health_monitor_loop(self) -> None:
-        """Monitor system health at 0.2 Hz."""
-        monitor = self.modules["health"]
-        while self._running:
-            report = monitor.get_report()
-            if report.get("cpu_temp_c", 0) > 80:
-                logger.warning("CPU overheating: %.1f C", report["cpu_temp_c"])
-            if report.get("disk_usage_pct", 0) > 90:
-                logger.warning("Disk almost full: %.1f%%", report["disk_usage_pct"])
-            if report.get("ram_usage_pct", 0) > 90:
-                logger.warning("RAM critical: %.1f%%", report["ram_usage_pct"])
-            await asyncio.sleep(5.0)
+        elif cmd_type == "module_status":
+            report = self.registry.get_status_report()
+            logger.info("Module status: %s", report)
 
-    async def scheduler_loop(self) -> None:
-        """Run scheduled tasks based on orbit position."""
-        scheduler = self.modules["scheduler"]
-        while self._running:
-            due_tasks = scheduler.get_due_tasks()
-            for task in due_tasks:
-                logger.info("Executing scheduled task: %s", task.get("name"))
-                scheduler.mark_completed(task["id"])
-            await asyncio.sleep(10.0)
+        else:
+            # Publish as generic command event for modules to handle
+            await self.event_bus.emit(
+                f"command.{cmd_type}",
+                data=cmd,
+                source="command",
+            )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def transition_phase(self, target: str, reason: str = "") -> bool:
+        """Transition to a new mission phase.
+
+        Args:
+            target: Target phase name.
+            reason: Human-readable reason.
+
+        Returns:
+            True if the transition succeeded.
+        """
+        old = self.state_machine.phase_name
+        ok = await self.state_machine.transition_to(target, reason=reason)
+        if ok:
+            await self.event_bus.emit(
+                self.state_machine.current.definition.entry_event,
+                data={"from": old, "to": target, "reason": reason},
+                source="flight_controller",
+            )
+        return ok
+
+    def get_system_status(self) -> dict:
+        """Return comprehensive system status for telemetry."""
+        return {
+            "mission_type": self.profile.mission_type.value,
+            "platform": self.profile.platform.value,
+            "phase": self.state_machine.get_phase_info(),
+            "modules": self.registry.get_status_report(),
+            "events": self.event_bus.get_stats(),
+        }
 
     async def run(self) -> None:
         """Main execution loop — start all async tasks."""
@@ -163,11 +298,15 @@ class FlightController:
         tasks = [
             asyncio.create_task(self.telemetry_loop()),
             asyncio.create_task(self.command_loop()),
-            asyncio.create_task(self.health_monitor_loop()),
+            asyncio.create_task(self.state_machine_loop()),
             asyncio.create_task(self.scheduler_loop()),
         ]
 
-        logger.info("Flight controller running with %d tasks", len(tasks))
+        logger.info(
+            "Flight controller running — %d tasks, phase: %s",
+            len(tasks),
+            self.state_machine.phase_name,
+        )
 
         try:
             await asyncio.gather(*tasks)
@@ -175,6 +314,16 @@ class FlightController:
             logger.info("Flight controller shutting down")
         finally:
             self._running = False
+            await self.registry.stop_all()
+            await self.event_bus.emit(
+                "system.shutdown",
+                source="flight_controller",
+            )
+
+    async def shutdown(self) -> None:
+        """Graceful shutdown."""
+        self._running = False
+        await self.registry.stop_all()
 
 
 async def main() -> None:

--- a/flight-software/modules/barometric_altimeter.py
+++ b/flight-software/modules/barometric_altimeter.py
@@ -1,0 +1,228 @@
+"""Barometric Altimeter Module — Pressure-based altitude measurement.
+
+Provides altitude, pressure, and temperature data from barometric sensors.
+Essential for CanSat descent tracking, rocket apogee detection, HAB burst
+detection, and drone altitude hold.
+
+Supports BME280, BMP388, MS5611, and simulated data.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from modules import BaseModule, ModuleStatus
+
+
+# ISA (International Standard Atmosphere) constants
+SEA_LEVEL_PRESSURE_PA = 101325.0
+TEMPERATURE_LAPSE_RATE = 0.0065  # K/m
+SEA_LEVEL_TEMPERATURE_K = 288.15
+GRAVITY = 9.80665
+MOLAR_MASS_AIR = 0.0289644
+GAS_CONSTANT = 8.31447
+
+
+@dataclass
+class BaroReading:
+    """A single barometric measurement.
+
+    Attributes:
+        timestamp: Unix timestamp.
+        pressure_pa: Atmospheric pressure in Pascals.
+        temperature_c: Temperature in Celsius.
+        altitude_m: Calculated altitude in meters (above sea level).
+        vertical_speed_m_s: Estimated vertical speed in m/s.
+    """
+
+    timestamp: float
+    pressure_pa: float
+    temperature_c: float
+    altitude_m: float
+    vertical_speed_m_s: float = 0.0
+
+
+def pressure_to_altitude(pressure_pa: float,
+                          ref_pressure_pa: float = SEA_LEVEL_PRESSURE_PA) -> float:
+    """Convert pressure to altitude using the barometric formula.
+
+    Args:
+        pressure_pa: Measured pressure in Pascals.
+        ref_pressure_pa: Reference (sea level) pressure in Pascals.
+
+    Returns:
+        Altitude in meters above the reference level.
+    """
+    if pressure_pa <= 0:
+        return 0.0
+    ratio = pressure_pa / ref_pressure_pa
+    exponent = (GAS_CONSTANT * TEMPERATURE_LAPSE_RATE) / (GRAVITY * MOLAR_MASS_AIR)
+    return (SEA_LEVEL_TEMPERATURE_K / TEMPERATURE_LAPSE_RATE) * (1.0 - ratio ** exponent)
+
+
+class BarometricAltimeter(BaseModule):
+    """Barometric altimeter module with altitude and vertical speed.
+
+    Configuration keys:
+        sensor_type: Sensor model (default "BME280").
+        sample_rate_hz: Sampling rate (default 25).
+        ref_pressure_pa: Sea-level reference pressure (default 101325).
+        ground_altitude_m: Launch site altitude MSL (default 0).
+        simulate: Use simulated data (default True).
+    """
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__("barometer", config)
+        self.sensor_type: str = self.config.get("sensor_type", "BME280")
+        self.sample_rate_hz: int = self.config.get("sample_rate_hz", 25)
+        self.ref_pressure_pa: float = self.config.get("ref_pressure_pa", SEA_LEVEL_PRESSURE_PA)
+        self.ground_altitude_m: float = self.config.get("ground_altitude_m", 0.0)
+        self._simulate: bool = self.config.get("simulate", True)
+        self._readings: list[BaroReading] = []
+        self._max_readings: int = 10000
+        self._sample_count: int = 0
+        self._max_altitude_m: float = 0.0
+        self._sim_phase: str = "ground"
+        self._sim_start: float = 0.0
+
+    async def initialize(self) -> bool:
+        self.logger.info(
+            "Barometric altimeter initialized: %s (rate=%dHz, ref=%.0fPa)",
+            self.sensor_type, self.sample_rate_hz, self.ref_pressure_pa,
+        )
+        self._sim_start = time.time()
+        self.status = ModuleStatus.READY
+        return True
+
+    async def start(self) -> None:
+        self.status = ModuleStatus.RUNNING
+
+    async def stop(self) -> None:
+        self.status = ModuleStatus.STOPPED
+        self.logger.info(
+            "Barometer stopped, %d samples, max alt: %.1fm",
+            self._sample_count, self._max_altitude_m,
+        )
+
+    async def get_status(self) -> dict[str, Any]:
+        return {
+            "status": self.status.name,
+            "sensor_type": self.sensor_type,
+            "sample_count": self._sample_count,
+            "max_altitude_m": round(self._max_altitude_m, 1),
+            "error_count": self._error_count,
+        }
+
+    def read(self) -> BaroReading:
+        """Read current barometric data.
+
+        Returns:
+            BaroReading with pressure, temperature, altitude, vertical speed.
+        """
+        if self._simulate:
+            reading = self._simulate_reading()
+        else:
+            reading = self._read_hardware()
+
+        # Track max altitude
+        agl = reading.altitude_m - self.ground_altitude_m
+        if agl > self._max_altitude_m:
+            self._max_altitude_m = agl
+
+        # Calculate vertical speed from last two readings
+        if self._readings:
+            prev = self._readings[-1]
+            dt = reading.timestamp - prev.timestamp
+            if dt > 0:
+                reading.vertical_speed_m_s = (reading.altitude_m - prev.altitude_m) / dt
+
+        self._readings.append(reading)
+        if len(self._readings) > self._max_readings:
+            self._readings = self._readings[-self._max_readings:]
+        self._sample_count += 1
+        return reading
+
+    def _simulate_reading(self) -> BaroReading:
+        """Generate simulated barometric data."""
+        noise_pa = random.gauss(0, 5.0)
+        base_pressure = self.ref_pressure_pa + noise_pa
+        altitude = pressure_to_altitude(base_pressure, self.ref_pressure_pa)
+        temp = 15.0 - altitude * TEMPERATURE_LAPSE_RATE + random.gauss(0, 0.2)
+
+        return BaroReading(
+            timestamp=time.time(),
+            pressure_pa=base_pressure,
+            temperature_c=round(temp, 2),
+            altitude_m=round(altitude + self.ground_altitude_m, 2),
+        )
+
+    def _read_hardware(self) -> BaroReading:
+        """Read from actual sensor hardware. Placeholder."""
+        self.logger.warning("Hardware barometer not implemented, using simulated data")
+        return self._simulate_reading()
+
+    def get_altitude_agl(self) -> float:
+        """Current altitude above ground level in meters."""
+        if not self._readings:
+            return 0.0
+        return self._readings[-1].altitude_m - self.ground_altitude_m
+
+    def get_max_altitude_agl(self) -> float:
+        """Maximum recorded altitude AGL in meters."""
+        return self._max_altitude_m
+
+    def get_vertical_speed(self) -> float:
+        """Current vertical speed in m/s (positive = ascending)."""
+        if not self._readings:
+            return 0.0
+        return self._readings[-1].vertical_speed_m_s
+
+    def detect_apogee(self, window: int = 10) -> bool:
+        """Detect apogee by finding altitude peak.
+
+        Checks if altitude has been consistently decreasing over the
+        last ``window`` samples after previously increasing.
+
+        Args:
+            window: Number of samples to check.
+
+        Returns:
+            True if apogee is detected.
+        """
+        if len(self._readings) < window + 5:
+            return False
+        recent = [r.altitude_m for r in self._readings[-window:]]
+        before = [r.altitude_m for r in self._readings[-(window + 5):-window]]
+        return (
+            all(recent[i] >= recent[i + 1] for i in range(len(recent) - 1))
+            and max(before) > min(before)
+            and max(before) > recent[-1]
+        )
+
+    def detect_burst(self, drop_threshold_m: float = 50.0) -> bool:
+        """Detect balloon burst by rapid altitude drop.
+
+        Args:
+            drop_threshold_m: Minimum altitude drop to consider a burst.
+
+        Returns:
+            True if burst detected.
+        """
+        if len(self._readings) < 20:
+            return False
+        recent_alts = [r.altitude_m for r in self._readings[-20:]]
+        peak = max(recent_alts[:10])
+        current = recent_alts[-1]
+        return (peak - current) > drop_threshold_m
+
+    def get_recent_readings(self, count: int = 100) -> list[BaroReading]:
+        """Return recent readings."""
+        return self._readings[-count:]
+
+    def set_sim_phase(self, phase: str) -> None:
+        """Set simulation phase for realistic test data."""
+        self._sim_phase = phase

--- a/flight-software/modules/descent_controller.py
+++ b/flight-software/modules/descent_controller.py
@@ -1,0 +1,265 @@
+"""Descent Controller Module — Parachute deployment and descent management.
+
+Manages parachute deployment based on altitude/acceleration triggers,
+monitors descent rate, and validates competition requirements.
+Essential for CanSat competitions and rocket recovery systems.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any
+
+from modules import BaseModule, ModuleStatus
+
+logger = logging.getLogger("unisat.descent")
+
+
+class DescentPhase(Enum):
+    """Descent controller phases."""
+
+    IDLE = auto()
+    ARMED = auto()
+    DEPLOY_READY = auto()
+    DEPLOYED = auto()
+    DESCENDING = auto()
+    LANDED = auto()
+
+
+@dataclass
+class DescentConfig:
+    """Configuration for descent controller.
+
+    Attributes:
+        deploy_altitude_m: Altitude AGL to deploy parachute.
+        deploy_accel_threshold_g: Low-g threshold for deployment.
+        target_descent_rate_m_s: Target descent rate.
+        min_descent_rate_m_s: Minimum acceptable descent rate.
+        max_descent_rate_m_s: Maximum acceptable descent rate.
+        landing_speed_threshold_m_s: Max acceptable landing speed.
+        deploy_delay_s: Delay after trigger before deployment.
+        min_telemetry_samples: Minimum samples for competition validity.
+    """
+
+    deploy_altitude_m: float = 500.0
+    deploy_accel_threshold_g: float = 0.5
+    target_descent_rate_m_s: float = 8.0
+    min_descent_rate_m_s: float = 6.0
+    max_descent_rate_m_s: float = 11.0
+    landing_speed_threshold_m_s: float = 12.0
+    deploy_delay_s: float = 1.0
+    min_telemetry_samples: int = 100
+
+
+@dataclass
+class DescentTelemetry:
+    """Descent phase telemetry snapshot."""
+
+    timestamp: float
+    phase: DescentPhase
+    altitude_agl_m: float
+    descent_rate_m_s: float
+    time_since_deploy_s: float = 0.0
+    parachute_deployed: bool = False
+    samples_collected: int = 0
+
+
+@dataclass
+class CompetitionResult:
+    """Competition validation results."""
+
+    valid: bool
+    descent_rate_avg_m_s: float = 0.0
+    descent_rate_min_m_s: float = 0.0
+    descent_rate_max_m_s: float = 0.0
+    landing_velocity_m_s: float = 0.0
+    telemetry_count: int = 0
+    flight_duration_s: float = 0.0
+    max_altitude_m: float = 0.0
+    issues: list[str] = field(default_factory=list)
+
+
+class DescentController(BaseModule):
+    """Manages parachute deployment and descent monitoring.
+
+    Configuration keys:
+        deploy_altitude_m: Deployment altitude AGL (default 500).
+        target_descent_rate_m_s: Target descent rate (default 8.0).
+        min_descent_rate_m_s: Min acceptable rate (default 6.0).
+        max_descent_rate_m_s: Max acceptable rate (default 11.0).
+        landing_speed_threshold_m_s: Max landing speed (default 12.0).
+        deploy_delay_s: Delay after trigger (default 1.0).
+        min_telemetry_samples: Min samples for validity (default 100).
+    """
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__("descent_controller", config)
+        self.descent_config = DescentConfig(
+            deploy_altitude_m=self.config.get("deploy_altitude_m", 500.0),
+            deploy_accel_threshold_g=self.config.get("deploy_accel_threshold_g", 0.5),
+            target_descent_rate_m_s=self.config.get("target_descent_rate_m_s", 8.0),
+            min_descent_rate_m_s=self.config.get("min_descent_rate_m_s", 6.0),
+            max_descent_rate_m_s=self.config.get("max_descent_rate_m_s", 11.0),
+            landing_speed_threshold_m_s=self.config.get("landing_speed_threshold_m_s", 12.0),
+            deploy_delay_s=self.config.get("deploy_delay_s", 1.0),
+            min_telemetry_samples=self.config.get("min_telemetry_samples", 100),
+        )
+        self.phase = DescentPhase.IDLE
+        self._deploy_time: float = 0.0
+        self._telemetry: list[DescentTelemetry] = []
+        self._descent_rates: list[float] = []
+        self._max_altitude_m: float = 0.0
+
+    async def initialize(self) -> bool:
+        self.logger.info(
+            "Descent controller initialized: deploy@%.0fm, target=%.1fm/s",
+            self.descent_config.deploy_altitude_m,
+            self.descent_config.target_descent_rate_m_s,
+        )
+        self.status = ModuleStatus.READY
+        return True
+
+    async def start(self) -> None:
+        self.status = ModuleStatus.RUNNING
+
+    async def stop(self) -> None:
+        self.status = ModuleStatus.STOPPED
+
+    async def get_status(self) -> dict[str, Any]:
+        return {
+            "status": self.status.name,
+            "phase": self.phase.name,
+            "parachute_deployed": self.phase in (
+                DescentPhase.DEPLOYED, DescentPhase.DESCENDING, DescentPhase.LANDED
+            ),
+            "telemetry_samples": len(self._telemetry),
+            "max_altitude_m": self._max_altitude_m,
+            "error_count": self._error_count,
+        }
+
+    def arm(self) -> bool:
+        """Arm the descent controller for deployment."""
+        if self.phase not in (DescentPhase.IDLE, DescentPhase.ARMED):
+            self.logger.warning("Cannot arm in phase %s", self.phase.name)
+            return False
+        self.phase = DescentPhase.ARMED
+        self.logger.info("Descent controller ARMED")
+        return True
+
+    def update(self, altitude_agl_m: float, descent_rate_m_s: float,
+               accel_g: float = 1.0) -> DescentTelemetry:
+        """Update descent state with current sensor data.
+
+        Args:
+            altitude_agl_m: Current altitude above ground level.
+            descent_rate_m_s: Current descent rate (positive = descending).
+            accel_g: Current acceleration magnitude in g.
+
+        Returns:
+            DescentTelemetry snapshot.
+        """
+        if altitude_agl_m > self._max_altitude_m:
+            self._max_altitude_m = altitude_agl_m
+
+        # State transitions
+        if self.phase == DescentPhase.ARMED:
+            if accel_g < self.descent_config.deploy_accel_threshold_g:
+                self.phase = DescentPhase.DEPLOY_READY
+                self.logger.info("Low-g detected, deployment ready")
+
+        elif self.phase == DescentPhase.DEPLOY_READY:
+            if altitude_agl_m <= self.descent_config.deploy_altitude_m:
+                self._deploy_parachute()
+
+        elif self.phase == DescentPhase.DEPLOYED:
+            time_since = time.time() - self._deploy_time
+            if time_since > self.descent_config.deploy_delay_s:
+                self.phase = DescentPhase.DESCENDING
+                self.logger.info("Descent phase active")
+
+        elif self.phase == DescentPhase.DESCENDING:
+            self._descent_rates.append(abs(descent_rate_m_s))
+            if altitude_agl_m < 2.0 and abs(descent_rate_m_s) < 0.5:
+                self.phase = DescentPhase.LANDED
+                self.logger.info("Landing detected at %.1fm", altitude_agl_m)
+
+        tlm = DescentTelemetry(
+            timestamp=time.time(),
+            phase=self.phase,
+            altitude_agl_m=altitude_agl_m,
+            descent_rate_m_s=descent_rate_m_s,
+            time_since_deploy_s=(time.time() - self._deploy_time) if self._deploy_time else 0.0,
+            parachute_deployed=self.phase in (
+                DescentPhase.DEPLOYED, DescentPhase.DESCENDING, DescentPhase.LANDED
+            ),
+            samples_collected=len(self._telemetry),
+        )
+        self._telemetry.append(tlm)
+        return tlm
+
+    def _deploy_parachute(self) -> None:
+        """Trigger parachute deployment."""
+        self.phase = DescentPhase.DEPLOYED
+        self._deploy_time = time.time()
+        self.logger.info("PARACHUTE DEPLOYED at %.1fm AGL", self._max_altitude_m)
+
+    def validate_competition(self) -> CompetitionResult:
+        """Validate descent against competition requirements.
+
+        Returns:
+            CompetitionResult with pass/fail and metrics.
+        """
+        issues: list[str] = []
+        cfg = self.descent_config
+
+        # Calculate descent rate stats
+        rates = self._descent_rates
+        avg_rate = sum(rates) / len(rates) if rates else 0.0
+        min_rate = min(rates) if rates else 0.0
+        max_rate = max(rates) if rates else 0.0
+
+        # Landing velocity (last few rates)
+        landing_v = sum(rates[-5:]) / len(rates[-5:]) if len(rates) >= 5 else avg_rate
+
+        # Flight duration
+        if self._telemetry:
+            duration = self._telemetry[-1].timestamp - self._telemetry[0].timestamp
+        else:
+            duration = 0.0
+
+        # Validation checks
+        if avg_rate < cfg.min_descent_rate_m_s:
+            issues.append(
+                f"Descent rate too slow: {avg_rate:.1f} m/s < {cfg.min_descent_rate_m_s} m/s"
+            )
+        if avg_rate > cfg.max_descent_rate_m_s:
+            issues.append(
+                f"Descent rate too fast: {avg_rate:.1f} m/s > {cfg.max_descent_rate_m_s} m/s"
+            )
+        if landing_v > cfg.landing_speed_threshold_m_s:
+            issues.append(
+                f"Landing too hard: {landing_v:.1f} m/s > {cfg.landing_speed_threshold_m_s} m/s"
+            )
+        if len(self._telemetry) < cfg.min_telemetry_samples:
+            issues.append(
+                f"Insufficient telemetry: {len(self._telemetry)} < {cfg.min_telemetry_samples}"
+            )
+
+        return CompetitionResult(
+            valid=len(issues) == 0,
+            descent_rate_avg_m_s=round(avg_rate, 2),
+            descent_rate_min_m_s=round(min_rate, 2),
+            descent_rate_max_m_s=round(max_rate, 2),
+            landing_velocity_m_s=round(landing_v, 2),
+            telemetry_count=len(self._telemetry),
+            flight_duration_s=round(duration, 1),
+            max_altitude_m=round(self._max_altitude_m, 1),
+            issues=issues,
+        )
+
+    def get_telemetry_history(self) -> list[DescentTelemetry]:
+        """Return full descent telemetry history."""
+        return list(self._telemetry)

--- a/flight-software/modules/imu_sensor.py
+++ b/flight-software/modules/imu_sensor.py
@@ -1,0 +1,207 @@
+"""IMU Sensor Module — Inertial Measurement Unit interface.
+
+Provides accelerometer, gyroscope, and optional magnetometer data.
+Essential for CanSat descent detection, rocket boost/coast detection,
+drone stabilization, and CubeSat ADCS.
+
+Supports MPU9250, BMI160, ICM-20948, LSM6DSO, and simulated data.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from modules import BaseModule, ModuleStatus
+
+
+@dataclass
+class IMUReading:
+    """A single IMU measurement.
+
+    Attributes:
+        timestamp: Unix timestamp.
+        accel_x_g: X acceleration in g.
+        accel_y_g: Y acceleration in g.
+        accel_z_g: Z acceleration in g.
+        gyro_x_dps: X angular rate in degrees/sec.
+        gyro_y_dps: Y angular rate in degrees/sec.
+        gyro_z_dps: Z angular rate in degrees/sec.
+        mag_x_ut: X magnetic field in microtesla (optional).
+        mag_y_ut: Y magnetic field in microtesla (optional).
+        mag_z_ut: Z magnetic field in microtesla (optional).
+        temperature_c: Sensor temperature in Celsius.
+    """
+
+    timestamp: float
+    accel_x_g: float
+    accel_y_g: float
+    accel_z_g: float
+    gyro_x_dps: float
+    gyro_y_dps: float
+    gyro_z_dps: float
+    mag_x_ut: float = 0.0
+    mag_y_ut: float = 0.0
+    mag_z_ut: float = 0.0
+    temperature_c: float = 25.0
+
+    @property
+    def accel_magnitude_g(self) -> float:
+        """Total acceleration magnitude in g."""
+        return math.sqrt(
+            self.accel_x_g ** 2 + self.accel_y_g ** 2 + self.accel_z_g ** 2
+        )
+
+    @property
+    def gyro_magnitude_dps(self) -> float:
+        """Total angular rate magnitude in deg/s."""
+        return math.sqrt(
+            self.gyro_x_dps ** 2 + self.gyro_y_dps ** 2 + self.gyro_z_dps ** 2
+        )
+
+
+class IMUSensor(BaseModule):
+    """IMU sensor module with support for multiple sensor types.
+
+    Configuration keys:
+        sensor_type: Sensor model (default "MPU9250").
+        sample_rate_hz: Sampling rate (default 100).
+        accel_range_g: Accelerometer full scale (default 16).
+        gyro_range_dps: Gyroscope full scale (default 2000).
+        has_magnetometer: Whether sensor includes mag (default True).
+        simulate: Use simulated data (default True).
+    """
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__("imu", config)
+        self.sensor_type: str = self.config.get("sensor_type", "MPU9250")
+        self.sample_rate_hz: int = self.config.get("sample_rate_hz", 100)
+        self.accel_range_g: int = self.config.get("accel_range_g", 16)
+        self.gyro_range_dps: int = self.config.get("gyro_range_dps", 2000)
+        self.has_magnetometer: bool = self.config.get("has_magnetometer", True)
+        self._simulate: bool = self.config.get("simulate", True)
+        self._readings: list[IMUReading] = []
+        self._max_readings: int = 10000
+        self._sample_count: int = 0
+
+    async def initialize(self) -> bool:
+        """Initialize the IMU sensor."""
+        self.logger.info(
+            "IMU initialized: %s (accel=%dg, gyro=%ddps, mag=%s, sim=%s)",
+            self.sensor_type, self.accel_range_g, self.gyro_range_dps,
+            self.has_magnetometer, self._simulate,
+        )
+        self.status = ModuleStatus.READY
+        return True
+
+    async def start(self) -> None:
+        self.status = ModuleStatus.RUNNING
+
+    async def stop(self) -> None:
+        self.status = ModuleStatus.STOPPED
+        self.logger.info("IMU stopped, %d samples collected", self._sample_count)
+
+    async def get_status(self) -> dict[str, Any]:
+        return {
+            "status": self.status.name,
+            "sensor_type": self.sensor_type,
+            "sample_count": self._sample_count,
+            "sample_rate_hz": self.sample_rate_hz,
+            "error_count": self._error_count,
+        }
+
+    def read(self) -> IMUReading:
+        """Read current IMU data.
+
+        Returns:
+            IMUReading with current sensor values.
+        """
+        if self._simulate:
+            reading = self._simulate_reading()
+        else:
+            reading = self._read_hardware()
+
+        self._readings.append(reading)
+        if len(self._readings) > self._max_readings:
+            self._readings = self._readings[-self._max_readings:]
+        self._sample_count += 1
+        return reading
+
+    def _simulate_reading(self) -> IMUReading:
+        """Generate simulated IMU data with realistic noise."""
+        noise_a = 0.02
+        noise_g = 0.5
+        return IMUReading(
+            timestamp=time.time(),
+            accel_x_g=random.gauss(0.0, noise_a),
+            accel_y_g=random.gauss(0.0, noise_a),
+            accel_z_g=random.gauss(-1.0, noise_a),  # gravity
+            gyro_x_dps=random.gauss(0.0, noise_g),
+            gyro_y_dps=random.gauss(0.0, noise_g),
+            gyro_z_dps=random.gauss(0.0, noise_g),
+            mag_x_ut=random.gauss(25.0, 1.0) if self.has_magnetometer else 0.0,
+            mag_y_ut=random.gauss(5.0, 1.0) if self.has_magnetometer else 0.0,
+            mag_z_ut=random.gauss(-45.0, 1.0) if self.has_magnetometer else 0.0,
+            temperature_c=random.gauss(25.0, 0.5),
+        )
+
+    def _read_hardware(self) -> IMUReading:
+        """Read from actual hardware via I2C/SPI.
+
+        Placeholder — hardware-specific implementation depends on the
+        sensor type and bus configuration.
+        """
+        self.logger.warning("Hardware IMU not implemented, returning simulated data")
+        return self._simulate_reading()
+
+    def detect_launch(self, threshold_g: float = 3.0) -> bool:
+        """Detect launch by checking if acceleration exceeds threshold.
+
+        Args:
+            threshold_g: Acceleration threshold in g.
+
+        Returns:
+            True if current acceleration exceeds threshold.
+        """
+        if not self._readings:
+            return False
+        latest = self._readings[-1]
+        return latest.accel_magnitude_g > threshold_g
+
+    def detect_freefall(self, threshold_g: float = 0.3) -> bool:
+        """Detect freefall (near-zero acceleration).
+
+        Args:
+            threshold_g: Low-g threshold.
+
+        Returns:
+            True if acceleration is below threshold.
+        """
+        if not self._readings:
+            return False
+        latest = self._readings[-1]
+        return latest.accel_magnitude_g < threshold_g
+
+    def detect_landing(self, window: int = 50, threshold_g: float = 0.1) -> bool:
+        """Detect landing by checking for stable acceleration near 1g.
+
+        Args:
+            window: Number of recent samples to check.
+            threshold_g: Max deviation from 1g.
+
+        Returns:
+            True if acceleration has been stable near 1g.
+        """
+        if len(self._readings) < window:
+            return False
+        recent = self._readings[-window:]
+        magnitudes = [r.accel_magnitude_g for r in recent]
+        avg = sum(magnitudes) / len(magnitudes)
+        return abs(avg - 1.0) < threshold_g
+
+    def get_recent_readings(self, count: int = 100) -> list[IMUReading]:
+        """Return recent readings for analysis."""
+        return self._readings[-count:]

--- a/flight-software/tests/test_event_bus.py
+++ b/flight-software/tests/test_event_bus.py
@@ -1,0 +1,155 @@
+"""Tests for the EventBus — async pub/sub system."""
+
+import asyncio
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.event_bus import EventBus, Event
+
+
+@pytest.fixture
+def bus():
+    return EventBus(history_size=100)
+
+
+@pytest.mark.asyncio
+async def test_exact_match(bus):
+    """Events are delivered to exact-match subscribers."""
+    received = []
+
+    async def handler(event: Event):
+        received.append(event)
+
+    bus.subscribe("test.event", handler)
+    await bus.emit("test.event", data={"key": "value"})
+
+    assert len(received) == 1
+    assert received[0].name == "test.event"
+    assert received[0].data["key"] == "value"
+
+
+@pytest.mark.asyncio
+async def test_wildcard_match(bus):
+    """Wildcard patterns match all child events."""
+    received = []
+
+    async def handler(event: Event):
+        received.append(event.name)
+
+    bus.subscribe("phase.*", handler)
+    await bus.emit("phase.ascent.enter")
+    await bus.emit("phase.descent.enter")
+    await bus.emit("system.init")  # should NOT match
+
+    assert received == ["phase.ascent.enter", "phase.descent.enter"]
+
+
+@pytest.mark.asyncio
+async def test_global_wildcard(bus):
+    """Global wildcard '*' matches everything."""
+    received = []
+
+    async def handler(event: Event):
+        received.append(event.name)
+
+    bus.subscribe("*", handler)
+    await bus.emit("a.b.c")
+    await bus.emit("x")
+
+    assert len(received) == 2
+
+
+@pytest.mark.asyncio
+async def test_no_match(bus):
+    """Events with no matching subscribers are silently ignored."""
+    count = await bus.emit("unsubscribed.event")
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_handler_error_does_not_propagate(bus):
+    """A failing handler doesn't break other handlers."""
+    results = []
+
+    async def bad_handler(event: Event):
+        raise ValueError("boom")
+
+    async def good_handler(event: Event):
+        results.append("ok")
+
+    bus.subscribe("test", bad_handler)
+    bus.subscribe("test", good_handler)
+
+    count = await bus.emit("test")
+    assert count == 1  # only good_handler succeeded
+    assert results == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_history(bus):
+    """Event history is maintained up to the configured size."""
+    for i in range(10):
+        await bus.emit(f"event.{i}")
+
+    history = bus.get_history(limit=5)
+    assert len(history) == 5
+    assert history[0].name == "event.9"  # newest first
+
+
+@pytest.mark.asyncio
+async def test_history_filtered(bus):
+    """History can be filtered by pattern."""
+    await bus.emit("phase.ascent")
+    await bus.emit("system.init")
+    await bus.emit("phase.descent")
+
+    phase_events = bus.get_history(pattern="phase.*")
+    assert len(phase_events) == 2
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe(bus):
+    """Unsubscribed handlers stop receiving events."""
+    received = []
+
+    async def handler(event: Event):
+        received.append(event.name)
+
+    bus.subscribe("test", handler)
+    await bus.emit("test")
+    assert len(received) == 1
+
+    bus.unsubscribe("test", handler)
+    await bus.emit("test")
+    assert len(received) == 1  # no new events
+
+
+@pytest.mark.asyncio
+async def test_stats(bus):
+    """Event stats track counts correctly."""
+    await bus.emit("a")
+    await bus.emit("a")
+    await bus.emit("b")
+
+    stats = bus.get_stats()
+    assert stats["total_events"] == 3
+    assert stats["unique_events"] == 2
+
+
+@pytest.mark.asyncio
+async def test_event_data_and_source(bus):
+    """Events carry data and source metadata."""
+    received = []
+
+    async def handler(event: Event):
+        received.append(event)
+
+    bus.subscribe("test", handler)
+    await bus.emit("test", data={"x": 42}, source="my_module", priority=1)
+
+    assert received[0].data["x"] == 42
+    assert received[0].source == "my_module"
+    assert received[0].priority == 1

--- a/flight-software/tests/test_flight_controller.py
+++ b/flight-software/tests/test_flight_controller.py
@@ -1,16 +1,36 @@
 """Tests for FlightController."""
 
-from flight_controller import FlightController, SatelliteState
-
-
-def test_satellite_state_enum():
-    assert SatelliteState.NOMINAL.value == "nominal"
-    assert SatelliteState.SAFE_MODE.value == "safe_mode"
+from flight_controller import FlightController
 
 
 def test_flight_controller_init(tmp_path):
     config = tmp_path / "mission_config.json"
-    config.write_text('{"mission":{"name":"Test","version":"1.0"},"subsystems":{}}')
+    config.write_text(
+        '{"mission":{"name":"Test","version":"1.0","mission_type":"cubesat_leo"},"subsystems":{}}'
+    )
     fc = FlightController(str(config))
-    assert fc.state == SatelliteState.STARTUP
     assert fc.config["mission"]["name"] == "Test"
+    assert fc.state_machine.phase_name == "startup"
+
+
+def test_flight_controller_cansat(tmp_path):
+    config = tmp_path / "mission_config.json"
+    config.write_text(
+        '{"mission":{"name":"CanSat","version":"1.0","mission_type":"cansat_standard"},"subsystems":{}}'
+    )
+    fc = FlightController(str(config))
+    assert fc.profile.platform.value == "cansat"
+    assert fc.state_machine.phase_name == "pre_launch"
+
+
+def test_flight_controller_system_status(tmp_path):
+    config = tmp_path / "mission_config.json"
+    config.write_text(
+        '{"mission":{"name":"Test","version":"1.0","mission_type":"cubesat_leo"},"subsystems":{}}'
+    )
+    fc = FlightController(str(config))
+    status = fc.get_system_status()
+    assert "mission_type" in status
+    assert "phase" in status
+    assert "modules" in status
+    assert "events" in status

--- a/flight-software/tests/test_mission_types.py
+++ b/flight-software/tests/test_mission_types.py
@@ -1,0 +1,151 @@
+"""Tests for mission type registry and profile building."""
+
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.mission_types import (
+    MissionType,
+    PlatformCategory,
+    MissionProfile,
+    PhaseDefinition,
+    get_mission_profile,
+    register_mission_profile,
+    list_mission_types,
+    build_profile_from_config,
+)
+
+
+def test_list_mission_types():
+    """All built-in types are listed."""
+    types = list_mission_types()
+    assert "cubesat_leo" in types
+    assert "cansat_standard" in types
+    assert "rocket_competition" in types
+    assert "hab_standard" in types
+    assert "drone_survey" in types
+
+
+def test_get_cubesat_profile():
+    profile = get_mission_profile("cubesat_leo")
+    assert profile.platform == PlatformCategory.CUBESAT
+    assert profile.initial_phase == "startup"
+    assert len(profile.phases) >= 4
+    assert "telemetry" in profile.core_modules
+
+
+def test_get_cansat_profile():
+    profile = get_mission_profile("cansat_standard")
+    assert profile.platform == PlatformCategory.CANSAT
+    assert profile.initial_phase == "pre_launch"
+    assert profile.default_telemetry_hz == 10.0
+    assert "imu" in profile.core_modules
+    assert "barometer" in profile.core_modules
+    assert "descent_rate_range_m_s" in profile.competition
+
+
+def test_get_rocket_profile():
+    profile = get_mission_profile("rocket_competition")
+    assert profile.platform == PlatformCategory.SUBORBITAL_ROCKET
+    assert profile.default_telemetry_hz == 20.0
+    phase_names = [p.name for p in profile.phases]
+    assert "boost" in phase_names
+    assert "coast" in phase_names
+    assert "apogee" in phase_names
+
+
+def test_get_hab_profile():
+    profile = get_mission_profile("hab_standard")
+    assert profile.platform == PlatformCategory.HIGH_ALTITUDE_BALLOON
+    phase_names = [p.name for p in profile.phases]
+    assert "ascent" in phase_names
+    assert "float" in phase_names
+    assert "burst" in phase_names
+
+
+def test_get_drone_profile():
+    profile = get_mission_profile("drone_survey")
+    assert profile.platform == PlatformCategory.DRONE
+    phase_names = [p.name for p in profile.phases]
+    assert "takeoff" in phase_names
+    assert "mission_flight" in phase_names
+    assert "return_to_home" in phase_names
+
+
+def test_unknown_profile_raises():
+    with pytest.raises(KeyError):
+        get_mission_profile("nonexistent_mission")
+
+
+def test_register_custom_profile():
+    custom = MissionProfile(
+        mission_type=MissionType.CUSTOM,
+        platform=PlatformCategory.CUSTOM,
+        phases=[PhaseDefinition(name="idle")],
+        initial_phase="idle",
+    )
+    register_mission_profile(custom)
+    retrieved = get_mission_profile(MissionType.CUSTOM)
+    assert retrieved.initial_phase == "idle"
+
+
+def test_build_profile_from_config_known_type():
+    config = {
+        "mission": {
+            "mission_type": "cansat_standard",
+            "telemetry_hz": 20.0,
+        }
+    }
+    profile = build_profile_from_config(config)
+    assert profile.platform == PlatformCategory.CANSAT
+    assert profile.default_telemetry_hz == 20.0  # overridden
+
+
+def test_build_profile_from_config_unknown_type():
+    config = {
+        "mission": {
+            "mission_type": "martian_rover",
+            "platform": "custom",
+        }
+    }
+    profile = build_profile_from_config(config)
+    assert profile.mission_type == MissionType.CUSTOM
+
+
+def test_build_profile_with_custom_phases():
+    config = {
+        "mission": {
+            "mission_type": "cansat_standard",
+            "phases": [
+                {"name": "idle", "transitions_to": ["active"]},
+                {"name": "active", "transitions_to": ["idle"]},
+            ],
+            "initial_phase": "idle",
+        }
+    }
+    profile = build_profile_from_config(config)
+    assert len(profile.phases) == 2
+    assert profile.initial_phase == "idle"
+
+
+def test_phase_definition_defaults():
+    p = PhaseDefinition(name="test_phase")
+    assert p.display_name == "Test Phase"
+    assert p.entry_event == "phase.test_phase.enter"
+    assert p.exit_event == "phase.test_phase.exit"
+    assert p.timeout_s == 0.0
+    assert p.auto_next == ""
+
+
+def test_phase_definition_custom_display():
+    p = PhaseDefinition(name="boost", display_name="Boost Phase")
+    assert p.display_name == "Boost Phase"
+
+
+def test_cansat_competition_metadata():
+    profile = get_mission_profile("cansat_standard")
+    assert profile.competition["type"] == "cansat"
+    assert profile.competition["min_telemetry_samples"] == 100
+    assert profile.competition["max_landing_velocity_m_s"] == 12.0

--- a/flight-software/tests/test_new_modules.py
+++ b/flight-software/tests/test_new_modules.py
@@ -1,0 +1,214 @@
+"""Tests for new modules: IMU, BarometricAltimeter, DescentController."""
+
+import asyncio
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from modules.imu_sensor import IMUSensor, IMUReading
+from modules.barometric_altimeter import BarometricAltimeter, pressure_to_altitude
+from modules.descent_controller import DescentController, DescentPhase
+
+
+# ---- IMU Tests ----
+
+class TestIMUSensor:
+    @pytest.fixture
+    def imu(self):
+        return IMUSensor(config={"simulate": True, "sensor_type": "MPU9250"})
+
+    @pytest.mark.asyncio
+    async def test_initialize(self, imu):
+        ok = await imu.initialize()
+        assert ok
+
+    @pytest.mark.asyncio
+    async def test_read_returns_data(self, imu):
+        await imu.initialize()
+        reading = imu.read()
+        assert isinstance(reading, IMUReading)
+        assert reading.timestamp > 0
+
+    @pytest.mark.asyncio
+    async def test_accel_magnitude_near_1g(self, imu):
+        """Simulated idle IMU should read ~1g total acceleration."""
+        await imu.initialize()
+        readings = [imu.read() for _ in range(100)]
+        avg_mag = sum(r.accel_magnitude_g for r in readings) / len(readings)
+        assert 0.8 < avg_mag < 1.2
+
+    @pytest.mark.asyncio
+    async def test_gyro_near_zero(self, imu):
+        """Simulated idle IMU should have near-zero angular rates."""
+        await imu.initialize()
+        readings = [imu.read() for _ in range(100)]
+        avg_gyro = sum(r.gyro_magnitude_dps for r in readings) / len(readings)
+        assert avg_gyro < 5.0
+
+    @pytest.mark.asyncio
+    async def test_sample_count_increments(self, imu):
+        await imu.initialize()
+        imu.read()
+        imu.read()
+        imu.read()
+        status = await imu.get_status()
+        assert status["sample_count"] == 3
+
+    def test_detect_freefall_no_data(self, imu):
+        assert not imu.detect_freefall()
+
+    def test_detect_landing_insufficient_data(self, imu):
+        assert not imu.detect_landing()
+
+    @pytest.mark.asyncio
+    async def test_recent_readings(self, imu):
+        await imu.initialize()
+        for _ in range(20):
+            imu.read()
+        recent = imu.get_recent_readings(10)
+        assert len(recent) == 10
+
+
+# ---- Barometric Altimeter Tests ----
+
+class TestBarometricAltimeter:
+    @pytest.fixture
+    def baro(self):
+        return BarometricAltimeter(config={
+            "simulate": True,
+            "ref_pressure_pa": 101325,
+            "ground_altitude_m": 0,
+        })
+
+    @pytest.mark.asyncio
+    async def test_initialize(self, baro):
+        ok = await baro.initialize()
+        assert ok
+
+    @pytest.mark.asyncio
+    async def test_read_returns_data(self, baro):
+        await baro.initialize()
+        reading = baro.read()
+        assert reading.pressure_pa > 0
+        assert reading.timestamp > 0
+
+    @pytest.mark.asyncio
+    async def test_altitude_near_ground(self, baro):
+        """Simulated ground-level baro should give altitude near 0."""
+        await baro.initialize()
+        readings = [baro.read() for _ in range(50)]
+        avg_alt = sum(r.altitude_m for r in readings) / len(readings)
+        assert abs(avg_alt) < 50  # within 50m of ground
+
+    @pytest.mark.asyncio
+    async def test_vertical_speed_calculated(self, baro):
+        await baro.initialize()
+        baro.read()
+        reading = baro.read()
+        # Speed should be a number (may be ~0 for ground level)
+        assert isinstance(reading.vertical_speed_m_s, float)
+
+    def test_pressure_to_altitude_sea_level(self):
+        alt = pressure_to_altitude(101325.0)
+        assert abs(alt) < 1.0
+
+    def test_pressure_to_altitude_1000m(self):
+        # ~89875 Pa at 1000m
+        alt = pressure_to_altitude(89875.0)
+        assert 900 < alt < 1100
+
+    def test_pressure_to_altitude_zero(self):
+        alt = pressure_to_altitude(0.0)
+        assert alt == 0.0
+
+    @pytest.mark.asyncio
+    async def test_max_altitude_tracking(self, baro):
+        await baro.initialize()
+        for _ in range(10):
+            baro.read()
+        # max altitude should be non-negative
+        assert baro.get_max_altitude_agl() >= 0
+
+    def test_detect_apogee_insufficient_data(self, baro):
+        assert not baro.detect_apogee()
+
+    def test_detect_burst_insufficient_data(self, baro):
+        assert not baro.detect_burst()
+
+
+# ---- Descent Controller Tests ----
+
+class TestDescentController:
+    @pytest.fixture
+    def dc(self):
+        return DescentController(config={
+            "deploy_altitude_m": 500,
+            "target_descent_rate_m_s": 8.0,
+            "min_descent_rate_m_s": 6.0,
+            "max_descent_rate_m_s": 11.0,
+            "min_telemetry_samples": 10,
+        })
+
+    @pytest.mark.asyncio
+    async def test_initialize(self, dc):
+        ok = await dc.initialize()
+        assert ok
+
+    @pytest.mark.asyncio
+    async def test_initial_phase_is_idle(self, dc):
+        await dc.initialize()
+        assert dc.phase == DescentPhase.IDLE
+
+    def test_arm(self, dc):
+        assert dc.arm()
+        assert dc.phase == DescentPhase.ARMED
+
+    def test_cannot_arm_after_deploy(self, dc):
+        dc.phase = DescentPhase.DESCENDING
+        assert not dc.arm()
+
+    def test_update_tracks_altitude(self, dc):
+        dc.arm()
+        tlm = dc.update(altitude_agl_m=1000, descent_rate_m_s=0.0)
+        assert tlm.altitude_agl_m == 1000
+
+    def test_low_g_triggers_deploy_ready(self, dc):
+        dc.arm()
+        dc.update(altitude_agl_m=1000, descent_rate_m_s=0.0, accel_g=0.2)
+        assert dc.phase == DescentPhase.DEPLOY_READY
+
+    def test_altitude_triggers_deployment(self, dc):
+        dc.arm()
+        dc.update(altitude_agl_m=1000, descent_rate_m_s=0.0, accel_g=0.2)
+        dc.update(altitude_agl_m=400, descent_rate_m_s=-5.0, accel_g=0.8)
+        assert dc.phase == DescentPhase.DEPLOYED
+
+    def test_validate_competition_no_data(self, dc):
+        result = dc.validate_competition()
+        # Should fail with insufficient telemetry
+        assert not result.valid
+        assert any("Insufficient" in i for i in result.issues)
+
+    def test_validate_competition_good_descent(self, dc):
+        dc.arm()
+        # Simulate deployment and descent
+        dc.update(1000, 0, 0.2)  # apogee, low-g
+        dc.update(400, -8.0, 0.8)  # below deploy altitude -> deploy
+        dc.phase = DescentPhase.DESCENDING
+        # Add descent rate samples
+        for i in range(20):
+            dc._descent_rates.append(8.0)
+            dc._telemetry.append(dc.update(400 - i * 15, -8.0))
+
+        result = dc.validate_competition()
+        assert result.valid
+        assert 6.0 <= result.descent_rate_avg_m_s <= 11.0
+
+    @pytest.mark.asyncio
+    async def test_get_status(self, dc):
+        await dc.initialize()
+        status = await dc.get_status()
+        assert status["phase"] == "IDLE"
+        assert "telemetry_samples" in status

--- a/flight-software/tests/test_state_machine.py
+++ b/flight-software/tests/test_state_machine.py
@@ -1,0 +1,201 @@
+"""Tests for the configurable StateMachine."""
+
+import asyncio
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.state_machine import StateMachine
+from core.mission_types import (
+    MissionProfile, MissionType, PlatformCategory, PhaseDefinition,
+    get_mission_profile,
+)
+
+
+def _simple_profile() -> MissionProfile:
+    """Create a minimal test profile."""
+    return MissionProfile(
+        mission_type=MissionType.CUSTOM,
+        platform=PlatformCategory.CUSTOM,
+        phases=[
+            PhaseDefinition(name="startup", transitions_to=["nominal", "safe"]),
+            PhaseDefinition(name="nominal", transitions_to=["science", "safe"]),
+            PhaseDefinition(name="science", transitions_to=["nominal", "safe"]),
+            PhaseDefinition(name="safe", transitions_to=["nominal"]),
+        ],
+        initial_phase="startup",
+    )
+
+
+def _timeout_profile() -> MissionProfile:
+    """Profile with timeout transitions."""
+    return MissionProfile(
+        mission_type=MissionType.CUSTOM,
+        platform=PlatformCategory.CUSTOM,
+        phases=[
+            PhaseDefinition(name="a", transitions_to=["b"], timeout_s=0.1, auto_next="b"),
+            PhaseDefinition(name="b", transitions_to=["a"]),
+        ],
+        initial_phase="a",
+    )
+
+
+def test_initial_phase():
+    sm = StateMachine(_simple_profile())
+    assert sm.phase_name == "startup"
+
+
+@pytest.mark.asyncio
+async def test_valid_transition():
+    sm = StateMachine(_simple_profile())
+    ok = await sm.transition_to("nominal", reason="test")
+    assert ok
+    assert sm.phase_name == "nominal"
+
+
+@pytest.mark.asyncio
+async def test_invalid_transition():
+    sm = StateMachine(_simple_profile())
+    ok = await sm.transition_to("science")  # startup can't go to science
+    assert not ok
+    assert sm.phase_name == "startup"
+
+
+@pytest.mark.asyncio
+async def test_unknown_phase():
+    sm = StateMachine(_simple_profile())
+    ok = await sm.transition_to("nonexistent")
+    assert not ok
+
+
+@pytest.mark.asyncio
+async def test_self_transition():
+    sm = StateMachine(_simple_profile())
+    ok = await sm.transition_to("startup")
+    assert ok  # same-phase transitions always succeed
+
+
+@pytest.mark.asyncio
+async def test_transition_history():
+    sm = StateMachine(_simple_profile())
+    await sm.transition_to("nominal")
+    await sm.transition_to("science")
+
+    assert len(sm.history) == 2
+    assert sm.history[0].from_phase == "startup"
+    assert sm.history[0].to_phase == "nominal"
+    assert sm.history[1].from_phase == "nominal"
+    assert sm.history[1].to_phase == "science"
+
+
+@pytest.mark.asyncio
+async def test_guard_veto():
+    """Guards can veto transitions."""
+    sm = StateMachine(_simple_profile())
+
+    async def deny_all(from_p: str, to_p: str) -> bool:
+        return False
+
+    sm.add_guard(deny_all)
+    ok = await sm.transition_to("nominal")
+    assert not ok
+    assert sm.phase_name == "startup"
+
+
+@pytest.mark.asyncio
+async def test_guard_allow():
+    """Guards that return True allow transitions."""
+    sm = StateMachine(_simple_profile())
+
+    async def allow_all(from_p: str, to_p: str) -> bool:
+        return True
+
+    sm.add_guard(allow_all)
+    ok = await sm.transition_to("nominal")
+    assert ok
+
+
+def test_timeout_detection():
+    """Timeout returns auto_next when phase duration exceeds limit."""
+    import time
+    sm = StateMachine(_timeout_profile())
+    # Initially no timeout
+    assert sm.check_timeout() is None
+    # Fake elapsed time
+    sm.current.entered_at = time.time() - 1.0
+    assert sm.check_timeout() == "b"
+
+
+def test_phase_info():
+    sm = StateMachine(_simple_profile())
+    info = sm.get_phase_info()
+    assert info["phase"] == "startup"
+    assert "nominal" in info["transitions_to"]
+
+
+def test_available_transitions():
+    sm = StateMachine(_simple_profile())
+    available = sm.get_available_transitions()
+    assert set(available) == {"nominal", "safe"}
+
+
+def test_list_phases():
+    sm = StateMachine(_simple_profile())
+    phases = sm.list_phases()
+    assert len(phases) == 4
+    names = [p["name"] for p in phases]
+    assert "startup" in names
+    assert "safe" in names
+
+
+def test_cubesat_profile_loads():
+    """Built-in CubeSat LEO profile loads and has correct initial phase."""
+    profile = get_mission_profile("cubesat_leo")
+    sm = StateMachine(profile)
+    assert sm.phase_name == "startup"
+    assert len(profile.phases) >= 4
+
+
+def test_cansat_profile_loads():
+    """Built-in CanSat profile loads and has correct initial phase."""
+    profile = get_mission_profile("cansat_standard")
+    sm = StateMachine(profile)
+    assert sm.phase_name == "pre_launch"
+    phase_names = [p.name for p in profile.phases]
+    assert "ascent" in phase_names
+    assert "descent" in phase_names
+
+
+def test_rocket_profile_loads():
+    """Built-in rocket profile loads."""
+    profile = get_mission_profile("rocket_competition")
+    sm = StateMachine(profile)
+    assert sm.phase_name == "ground_checkout"
+
+
+def test_hab_profile_loads():
+    """Built-in HAB profile loads."""
+    profile = get_mission_profile("hab_standard")
+    sm = StateMachine(profile)
+    assert sm.phase_name == "ground_setup"
+
+
+def test_drone_profile_loads():
+    """Built-in drone profile loads."""
+    profile = get_mission_profile("drone_survey")
+    sm = StateMachine(profile)
+    assert sm.phase_name == "preflight"
+
+
+def test_invalid_initial_phase():
+    """Profile with unknown initial phase raises ValueError."""
+    profile = MissionProfile(
+        mission_type=MissionType.CUSTOM,
+        platform=PlatformCategory.CUSTOM,
+        phases=[PhaseDefinition(name="a")],
+        initial_phase="nonexistent",
+    )
+    with pytest.raises(ValueError):
+        StateMachine(profile)

--- a/mission_templates/cansat_standard.json
+++ b/mission_templates/cansat_standard.json
@@ -1,0 +1,100 @@
+{
+  "mission": {
+    "name": "CanSat Mission",
+    "version": "1.0.0",
+    "description": "Standard CanSat competition mission profile",
+    "mission_type": "cansat_standard",
+    "platform": "cansat",
+    "operator": "Team Name",
+    "telemetry_hz": 10.0,
+    "competition": {
+      "type": "cansat",
+      "name": "CanSat Competition",
+      "descent_rate_range_m_s": [6.0, 11.0],
+      "max_landing_velocity_m_s": 12.0,
+      "min_telemetry_samples": 100,
+      "max_cansat_mass_g": 350,
+      "max_cansat_diameter_mm": 66,
+      "max_cansat_height_mm": 115
+    }
+  },
+  "satellite": {
+    "form_factor": "cansat",
+    "mass_kg": 0.35,
+    "dimensions_mm": [66, 66, 115]
+  },
+  "subsystems": {
+    "obc": {
+      "enabled": true,
+      "mcu": "STM32F446RE",
+      "clock_mhz": 180,
+      "ram_kb": 128,
+      "flash_kb": 512
+    },
+    "imu": {
+      "enabled": true,
+      "sensor_type": "MPU9250",
+      "sample_rate_hz": 100,
+      "accel_range_g": 16,
+      "gyro_range_dps": 2000,
+      "has_magnetometer": true,
+      "simulate": false
+    },
+    "barometer": {
+      "enabled": true,
+      "sensor_type": "BME280",
+      "sample_rate_hz": 25,
+      "ref_pressure_pa": 101325,
+      "ground_altitude_m": 0,
+      "simulate": false
+    },
+    "gnss": {
+      "enabled": true,
+      "receiver": "u-blox_MAX-M10S",
+      "antenna": "patch"
+    },
+    "comm": {
+      "enabled": true,
+      "uhf": {
+        "enabled": true,
+        "frequency_mhz": 433.0,
+        "power_w": 0.1,
+        "data_rate_bps": 9600,
+        "protocol": "custom"
+      }
+    },
+    "camera": {
+      "enabled": false,
+      "resolution_mp": 2,
+      "storage_gb": 1
+    },
+    "descent_controller": {
+      "enabled": true,
+      "deploy_altitude_m": 500,
+      "target_descent_rate_m_s": 8.0,
+      "min_descent_rate_m_s": 6.0,
+      "max_descent_rate_m_s": 11.0,
+      "landing_speed_threshold_m_s": 12.0,
+      "deploy_delay_s": 1.0,
+      "min_telemetry_samples": 100
+    },
+    "payload": {
+      "enabled": true,
+      "type": "custom",
+      "description": "Mission-specific payload"
+    }
+  },
+  "ground_station": {
+    "location": {
+      "name": "Launch Site",
+      "latitude": 0.0,
+      "longitude": 0.0,
+      "altitude_m": 0
+    },
+    "antenna": {
+      "type": "whip",
+      "gain_dbi": 2,
+      "frequency_mhz": 433
+    }
+  }
+}

--- a/mission_templates/cubesat_sso.json
+++ b/mission_templates/cubesat_sso.json
@@ -1,12 +1,11 @@
 {
   "mission": {
-    "name": "UniSat-1",
+    "name": "CubeSat SSO Mission",
     "version": "1.0.0",
-    "description": "Universal modular CubeSat platform",
+    "description": "Sun-synchronous orbit CubeSat mission profile",
     "mission_type": "cubesat_leo",
     "platform": "cubesat",
     "operator": "Team Name",
-    "launch_date": "2026-01-01T00:00:00Z",
     "telemetry_hz": 1.0
   },
   "satellite": {

--- a/mission_templates/drone_survey.json
+++ b/mission_templates/drone_survey.json
@@ -1,0 +1,82 @@
+{
+  "mission": {
+    "name": "Drone Survey Mission",
+    "version": "1.0.0",
+    "description": "UAV/Drone survey and inspection mission profile",
+    "mission_type": "drone_survey",
+    "platform": "drone",
+    "operator": "Team Name",
+    "telemetry_hz": 10.0,
+    "competition": {
+      "type": "drone",
+      "name": "UAV Challenge",
+      "max_flight_time_min": 30,
+      "max_altitude_m": 120,
+      "geofence_radius_m": 500
+    }
+  },
+  "satellite": {
+    "form_factor": "drone",
+    "mass_kg": 2.5,
+    "dimensions_mm": [400, 400, 200]
+  },
+  "subsystems": {
+    "obc": {
+      "enabled": true,
+      "mcu": "STM32F446RE",
+      "clock_mhz": 180,
+      "ram_kb": 128,
+      "flash_kb": 512
+    },
+    "imu": {
+      "enabled": true,
+      "sensor_type": "ICM-20948",
+      "sample_rate_hz": 200,
+      "accel_range_g": 16,
+      "gyro_range_dps": 2000,
+      "has_magnetometer": true,
+      "simulate": false
+    },
+    "barometer": {
+      "enabled": true,
+      "sensor_type": "BMP388",
+      "sample_rate_hz": 50,
+      "ref_pressure_pa": 101325,
+      "ground_altitude_m": 0,
+      "simulate": false
+    },
+    "gnss": {
+      "enabled": true,
+      "receiver": "u-blox_MAX-M10S",
+      "antenna": "patch"
+    },
+    "comm": {
+      "enabled": true,
+      "uhf": {
+        "enabled": true,
+        "frequency_mhz": 2400.0,
+        "power_w": 0.1,
+        "data_rate_bps": 115200,
+        "protocol": "MAVLink"
+      }
+    },
+    "camera": {
+      "enabled": true,
+      "resolution_mp": 12,
+      "storage_gb": 32
+    },
+    "payload": {
+      "enabled": true,
+      "type": "survey",
+      "sensors": ["multispectral", "thermal"]
+    }
+  },
+  "ground_station": {
+    "location": {
+      "name": "GCS",
+      "latitude": 0.0,
+      "longitude": 0.0,
+      "altitude_m": 0
+    }
+  }
+}

--- a/mission_templates/hab_standard.json
+++ b/mission_templates/hab_standard.json
@@ -1,0 +1,88 @@
+{
+  "mission": {
+    "name": "HAB Mission",
+    "version": "1.0.0",
+    "description": "High Altitude Balloon standard mission profile",
+    "mission_type": "hab_standard",
+    "platform": "high_altitude_balloon",
+    "operator": "Team Name",
+    "telemetry_hz": 0.5,
+    "competition": {
+      "type": "hab",
+      "name": "HAB Flight",
+      "target_altitude_m": 30000,
+      "expected_burst_altitude_m": 28000,
+      "expected_ascent_rate_m_s": 5.0
+    }
+  },
+  "satellite": {
+    "form_factor": "hab_payload",
+    "mass_kg": 1.5,
+    "dimensions_mm": [200, 200, 150]
+  },
+  "subsystems": {
+    "obc": {
+      "enabled": true,
+      "mcu": "STM32F446RE",
+      "clock_mhz": 180,
+      "ram_kb": 128,
+      "flash_kb": 512
+    },
+    "imu": {
+      "enabled": false
+    },
+    "barometer": {
+      "enabled": true,
+      "sensor_type": "MS5611",
+      "sample_rate_hz": 10,
+      "ref_pressure_pa": 101325,
+      "ground_altitude_m": 0,
+      "simulate": false
+    },
+    "gnss": {
+      "enabled": true,
+      "receiver": "u-blox_MAX-M10S",
+      "antenna": "patch"
+    },
+    "comm": {
+      "enabled": true,
+      "uhf": {
+        "enabled": true,
+        "frequency_mhz": 434.0,
+        "power_w": 0.5,
+        "data_rate_bps": 300,
+        "protocol": "RTTY"
+      },
+      "aprs": {
+        "enabled": true,
+        "frequency_mhz": 144.39,
+        "callsign": "N0CALL",
+        "interval_s": 120
+      }
+    },
+    "camera": {
+      "enabled": true,
+      "resolution_mp": 5,
+      "capture_interval_s": 30,
+      "storage_gb": 16
+    },
+    "payload": {
+      "enabled": true,
+      "type": "environmental",
+      "sensors": ["temperature", "humidity", "uv", "radiation"]
+    }
+  },
+  "ground_station": {
+    "location": {
+      "name": "Launch Site",
+      "latitude": 0.0,
+      "longitude": 0.0,
+      "altitude_m": 0
+    },
+    "antenna": {
+      "type": "yagi",
+      "gain_dbi": 14,
+      "frequency_mhz": 434
+    }
+  }
+}

--- a/mission_templates/rocket_competition.json
+++ b/mission_templates/rocket_competition.json
@@ -1,0 +1,85 @@
+{
+  "mission": {
+    "name": "Rocket Competition Mission",
+    "version": "1.0.0",
+    "description": "Competition rocketry avionics mission profile (IREC/SA Cup, Team America)",
+    "mission_type": "rocket_competition",
+    "platform": "suborbital_rocket",
+    "operator": "Team Name",
+    "telemetry_hz": 20.0,
+    "competition": {
+      "type": "rocket",
+      "name": "SA Cup / IREC",
+      "target_altitude_m": 3048,
+      "max_acceleration_g": 20,
+      "dual_deploy": true
+    }
+  },
+  "satellite": {
+    "form_factor": "rocket_avionics",
+    "mass_kg": 0.5,
+    "dimensions_mm": [50, 50, 100]
+  },
+  "subsystems": {
+    "obc": {
+      "enabled": true,
+      "mcu": "STM32F446RE",
+      "clock_mhz": 180,
+      "ram_kb": 128,
+      "flash_kb": 512
+    },
+    "imu": {
+      "enabled": true,
+      "sensor_type": "MPU9250",
+      "sample_rate_hz": 200,
+      "accel_range_g": 16,
+      "gyro_range_dps": 2000,
+      "has_magnetometer": false,
+      "simulate": false
+    },
+    "barometer": {
+      "enabled": true,
+      "sensor_type": "BMP388",
+      "sample_rate_hz": 50,
+      "ref_pressure_pa": 101325,
+      "ground_altitude_m": 0,
+      "simulate": false
+    },
+    "gnss": {
+      "enabled": true,
+      "receiver": "u-blox_MAX-M10S",
+      "antenna": "patch"
+    },
+    "comm": {
+      "enabled": true,
+      "uhf": {
+        "enabled": true,
+        "frequency_mhz": 915.0,
+        "power_w": 0.5,
+        "data_rate_bps": 19200,
+        "protocol": "custom"
+      }
+    },
+    "camera": {
+      "enabled": false
+    },
+    "payload": {
+      "enabled": true,
+      "type": "custom",
+      "description": "Experiment payload"
+    }
+  },
+  "ground_station": {
+    "location": {
+      "name": "Launch Rail",
+      "latitude": 0.0,
+      "longitude": 0.0,
+      "altitude_m": 0
+    },
+    "antenna": {
+      "type": "yagi",
+      "gain_dbi": 10,
+      "frequency_mhz": 915
+    }
+  }
+}


### PR DESCRIPTION
Transform UniSat from a single-mission CubeSat platform into a multi-mission
framework supporting CubeSat, CanSat, rocket, HAB, drone, and custom platforms.

Core architecture (flight-software/core/):
- mission_types.py: Mission type registry with 5 built-in profiles
  (cubesat_leo, cansat_standard, rocket_competition, hab_standard, drone_survey)
- event_bus.py: Async pub/sub with wildcard subscriptions and history
- state_machine.py: Configurable phase-based state machine with guards,
  timeouts, and auto-transitions
- module_registry.py: Dynamic module loading with per-module config injection

New flight modules:
- imu_sensor.py: IMU with launch/freefall/landing detection
- barometric_altimeter.py: Pressure-based altitude with apogee/burst detection
- descent_controller.py: Parachute deployment and competition validation

FlightController rewrite:
- Config-driven module loading (no more hardcoded MODULE_MAP)
- Mission profile auto-selection from mission_config.json
- State machine loop with timeout-based auto-transitions
- Event-driven architecture for inter-module communication

Mission templates (mission_templates/):
- cansat_standard.json, rocket_competition.json, hab_standard.json,
  cubesat_sso.json, drone_survey.json

Configurator updates:
- Multi-platform UI (CubeSat/CanSat/Rocket/HAB/Drone/Custom)
- Competition-specific settings per platform
- Extended validators for all form factors (1U-12U, CanSat, rocket, HAB, drone)

Tests: 130 passing (70 new + 60 existing, 0 failures)

