### PR TITLE
test: skip CommunicationManager tests instead of erroring when pyserial is absent

### DIFF
--- a/docs/guides/USAGE_GUIDE.md
+++ b/docs/guides/USAGE_GUIDE.md
@@ -216,6 +216,13 @@ make test-c      # ctest 25/25 (post-TRL-5)
 make test-py     # pytest 56+ тестов
 ```
 
+> **Note on pyserial / flight-software tests.** A full green pytest run on
+> `flight-software/tests/` requires `pip install -r flight-software/requirements.txt`
+> (pyserial is the one that trips this). Without it, the
+> `CommunicationManager` tests auto-skip cleanly — they no longer abort
+> collection. The rest of the suite (camera, module_registry, …) still
+> runs end-to-end.
+
 Или вручную:
 
 ```bash

--- a/flight-software/tests/test_communication_mocked.py
+++ b/flight-software/tests/test_communication_mocked.py
@@ -26,6 +26,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# Every test in this file patches or instantiates a real pyserial object,
+# so skip the whole module cleanly on a checkout that does not have
+# pyserial installed (CI images without flight-software/requirements.txt).
+# Without this guard, pytest raises a collection error on `import serial`
+# below, which counts as a hard failure instead of a skip — see #8.
+pytest.importorskip("serial", reason="pyserial required for CommunicationManager tests")
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from modules.communication import CommunicationManager, SYNC_WORD

--- a/flight-software/tests/test_coverage_boost.py
+++ b/flight-software/tests/test_coverage_boost.py
@@ -114,9 +114,26 @@ async def test_camera_cleanup_oldest(camera_tmpdir: Path) -> None:
 #  communication.py
 # =========================================================================
 
-from modules.communication import CommunicationManager
+# pyserial is an optional runtime dep (only the flight RPi needs it). On a
+# bare CI image without `pip install -r flight-software/requirements.txt`,
+# `modules.communication` fails to import on `import serial`. Guard the
+# import and skip the communication tests individually so the rest of this
+# file (camera, module_registry) still runs. See #8.
+try:
+    from modules.communication import CommunicationManager
+
+    _HAS_PYSERIAL = True
+except ImportError:
+    CommunicationManager = None  # type: ignore[assignment,misc]
+    _HAS_PYSERIAL = False
+
+_requires_pyserial = pytest.mark.skipif(
+    not _HAS_PYSERIAL,
+    reason="pyserial required for CommunicationManager tests",
+)
 
 
+@_requires_pyserial
 @pytest.mark.asyncio
 async def test_communication_lifecycle() -> None:
     """Communication opens a real serial port in the default config.
@@ -131,6 +148,7 @@ async def test_communication_lifecycle() -> None:
     await comm.stop()
 
 
+@_requires_pyserial
 def test_communication_sign_verify_round_trip() -> None:
     comm = CommunicationManager({
         "hmac_key": "0123456789abcdef0123456789abcdef",
@@ -142,6 +160,7 @@ def test_communication_sign_verify_round_trip() -> None:
     assert comm.verify_command(cmd, sig) is True
 
 
+@_requires_pyserial
 def test_communication_verify_rejects_tampered_signature() -> None:
     comm = CommunicationManager({
         "hmac_key": "0123456789abcdef0123456789abcdef",
@@ -152,6 +171,7 @@ def test_communication_verify_rejects_tampered_signature() -> None:
     assert comm.verify_command(cmd, bytes(sig)) is False
 
 
+@_requires_pyserial
 def test_communication_verify_rejects_tampered_command() -> None:
     comm = CommunicationManager({
         "hmac_key": "0123456789abcdef0123456789abcdef",
@@ -161,6 +181,7 @@ def test_communication_verify_rejects_tampered_command() -> None:
     assert comm.verify_command(b"pong", sig) is False
 
 
+@_requires_pyserial
 @pytest.mark.asyncio
 async def test_communication_send_packet(tmp_path: Path) -> None:
     """send_packet returns False without an open serial port
@@ -172,6 +193,7 @@ async def test_communication_send_packet(tmp_path: Path) -> None:
     assert isinstance(ok, bool)
 
 
+@_requires_pyserial
 @pytest.mark.asyncio
 async def test_communication_receive_packet_empty_returns_none() -> None:
     comm = CommunicationManager({"simulate": True})
@@ -181,6 +203,7 @@ async def test_communication_receive_packet_empty_returns_none() -> None:
     assert pkt is None or isinstance(pkt, bytes)
 
 
+@_requires_pyserial
 @pytest.mark.asyncio
 async def test_communication_send_authenticated_command() -> None:
     comm = CommunicationManager({
@@ -192,6 +215,7 @@ async def test_communication_send_authenticated_command() -> None:
     assert isinstance(ok, bool)
 
 
+@_requires_pyserial
 def test_communication_seconds_since_last_rx_is_float() -> None:
     comm = CommunicationManager({"simulate": True})
     val = comm.seconds_since_last_rx()
@@ -199,6 +223,7 @@ def test_communication_seconds_since_last_rx_is_float() -> None:
     assert val >= 0.0
 
 
+@_requires_pyserial
 def test_communication_is_connected_returns_bool() -> None:
     comm = CommunicationManager({"simulate": True})
     result = comm.is_connected()


### PR DESCRIPTION
## Summary

Closes #8 -- on a fresh checkout without \`pip install -r flight-software/requirements.txt\`, \`pytest flight-software/tests/\` no longer aborts with \`ModuleNotFoundError: No module named 'serial'\`. The two affected test modules now skip cleanly:

- \`test_communication_mocked.py\` -- every test in this file patches or instantiates a real pyserial object, so a module-level \`pytest.importorskip(\"serial\")\` skips the whole file in one place.
- \`test_coverage_boost.py\` -- only its communication tests need pyserial (camera and module_registry tests do not). Wrap \`from modules.communication import CommunicationManager\` in try/except and gate the 10 communication tests with \`@_requires_pyserial = pytest.mark.skipif(not _HAS_PYSERIAL, ...)\`. The camera and module_registry tests still run.

Plus a short note in \`docs/guides/USAGE_GUIDE.md\` explaining that a full green requires \`pip install -r flight-software/requirements.txt\`.

## Why gate inside the file instead of in conftest.py

Putting \`pytest.importorskip(\"serial\")\` in a conftest.py would skip every test under that conftest, not just the CommunicationManager ones. The camera and module_registry tests should still run without pyserial, so the guard has to live at test-file or test-function granularity.

## Verification

Clean venv with numpy + pillow but **no** pyserial:

\`\`\`
$ pytest flight-software/tests/test_communication_mocked.py flight-software/tests/test_coverage_boost.py -q
......sssssssss......                                                    [100%]
12 passed, 10 skipped in 2.26s
\`\`\`

Same venv **with** \`pip install pyserial\`:

\`\`\`
$ pytest flight-software/tests/test_communication_mocked.py flight-software/tests/test_coverage_boost.py -q
....................................                                     [100%]
36 passed in 0.53s
\`\`\`

Zero collection errors in both runs.

## Definition of done

- [x] Collection no longer errors on a checkout without pyserial -- communication tests report as skipped
- [x] Installing pyserial re-enables the previously-skipped tests with no regression (36/36 pass locally)
- [x] USAGE_GUIDE documents the \`pip install -r flight-software/requirements.txt\` requirement and the auto-skip behavior

Closes #8