### PR TITLE
chore(configurator): migrate tests from legacy keys to canonical

### DIFF
--- a/configurator/tests/test_validators.py
+++ b/configurator/tests/test_validators.py
@@ -24,82 +24,82 @@ MINIMAL = {"eps": True, "comm_uhf": True}
 # --- Mass Validator ---
 
 def test_mass_3u_within_limit():
-    result = validate_mass("3U", ALL_ENABLED)
+    result = validate_mass("cubesat_3u", ALL_ENABLED)
     assert result.valid is True
     assert result.total_kg <= result.limit_kg
 
 
 def test_mass_1u_over_limit():
-    result = validate_mass("1U", ALL_ENABLED)
+    result = validate_mass("cubesat_1u", ALL_ENABLED)
     assert result.valid is False
     assert result.total_kg > result.limit_kg
 
 
 def test_mass_6u_plenty_of_margin():
-    result = validate_mass("6U", ALL_ENABLED)
+    result = validate_mass("cubesat_6u", ALL_ENABLED)
     assert result.valid is True
     assert result.margin_kg > 5.0
 
 
 def test_mass_includes_20pct_margin():
-    result = validate_mass("3U", ALL_ENABLED)
+    result = validate_mass("cubesat_3u", ALL_ENABLED)
     assert "margin_20pct" in result.items
     assert result.items["margin_20pct"] > 0
 
 
 def test_mass_minimal_config():
-    result = validate_mass("1U", MINIMAL)
-    assert result.total_kg < validate_mass("1U", ALL_ENABLED).total_kg
+    result = validate_mass("cubesat_1u", MINIMAL)
+    assert result.total_kg < validate_mass("cubesat_1u", ALL_ENABLED).total_kg
 
 
 # --- Power Validator ---
 
 def test_power_3u_positive_balance():
-    result = validate_power("3U", 0.295, ALL_ENABLED)
+    result = validate_power("cubesat_3u", 0.295, ALL_ENABLED)
     assert result.generation_w > 0
     assert result.consumption_nominal_w > 0
 
 
 def test_power_generation_increases_with_panels():
-    power_3u = validate_power("3U", 0.295, ALL_ENABLED)
-    power_6u = validate_power("6U", 0.295, ALL_ENABLED)
+    power_3u = validate_power("cubesat_3u", 0.295, ALL_ENABLED)
+    power_6u = validate_power("cubesat_6u", 0.295, ALL_ENABLED)
     assert power_6u.generation_w > power_3u.generation_w
 
 
 def test_power_consumption_increases_with_subsystems():
-    minimal = validate_power("3U", 0.295, MINIMAL)
-    full = validate_power("3U", 0.295, ALL_ENABLED)
+    minimal = validate_power("cubesat_3u", 0.295, MINIMAL)
+    full = validate_power("cubesat_3u", 0.295, ALL_ENABLED)
     assert full.consumption_nominal_w > minimal.consumption_nominal_w
 
 
 def test_power_peak_exceeds_nominal():
-    result = validate_power("3U", 0.295, ALL_ENABLED)
+    result = validate_power("cubesat_3u", 0.295, ALL_ENABLED)
     assert result.consumption_peak_w >= result.consumption_nominal_w
 
 
 # --- Volume Validator ---
 
 def test_volume_3u_fits():
-    result = validate_volume("3U", ALL_ENABLED)
+    result = validate_volume("cubesat_3u", ALL_ENABLED)
     assert result.valid is True
     assert result.utilization_pct < 100
 
 
 def test_volume_1u_tight():
-    result = validate_volume("1U", ALL_ENABLED)
+    result = validate_volume("cubesat_1u", ALL_ENABLED)
     # 1U with everything enabled might be tight
     assert result.total_cm3 > 0
 
 
 def test_volume_6u_lots_of_space():
-    result = validate_volume("6U", ALL_ENABLED)
+    result = validate_volume("cubesat_6u", ALL_ENABLED)
     assert result.valid is True
     assert result.utilization_pct < 50
 
 
 def test_volume_utilization_increases():
-    minimal = validate_volume("3U", MINIMAL)
-    full = validate_volume("3U", ALL_ENABLED)
+    minimal = validate_volume("cubesat_3u", MINIMAL)
+    full = validate_volume("cubesat_3u", ALL_ENABLED)
     assert full.utilization_pct > minimal.utilization_pct
 
 

--- a/configurator/validators/power_validator.py
+++ b/configurator/validators/power_validator.py
@@ -1,4 +1,9 @@
-"""Power Validator — Check energy balance for the mission."""
+"""Power Validator — Check energy balance for the mission.
+
+Accepts both canonical form-factor keys (``cubesat_3u`` …) and the pre-v1.3.0
+legacy keys (``3U`` …) via the same ``_ALIASES`` pattern used by
+``mass_validator`` and ``volume_validator``.
+"""
 
 from dataclasses import dataclass
 
@@ -30,18 +35,47 @@ SUBSYSTEM_POWER = {
 }
 
 
+# Legacy-to-canonical key aliases — older configs and UI code used the short
+# CubeSat codes ("1U", "3U" …) before v1.3.0 consolidated everything under the
+# form_factors registry. Kept so pre-migration configs still resolve.
+_ALIASES: dict[str, str] = {
+    "1U": "cubesat_1u",
+    "1.5U": "cubesat_1_5u",
+    "2U": "cubesat_2u",
+    "3U": "cubesat_3u",
+    "6U": "cubesat_6u",
+    "12U": "cubesat_12u",
+}
+
+
+def _canonical_key(form_factor: str) -> str:
+    """Return the registry key for ``form_factor`` (accepts legacy aliases)."""
+    return _ALIASES.get(form_factor, form_factor)
+
+
+_CANONICAL_PANEL_COUNTS: dict[str, int] = {
+    "cubesat_1u": 4,
+    "cubesat_2u": 4,
+    "cubesat_3u": 6,
+    "cubesat_6u": 8,
+    "cubesat_12u": 10,
+    "cansat_standard": 0,
+    "cansat_custom": 0,
+    "rocket_avionics": 0,
+    "rocket_custom": 0,
+    "hab_payload_small": 0,
+    "hab_payload_medium": 0,
+    "hab_payload_large": 0,
+    "drone_small": 0,
+    "drone_medium": 0,
+    "custom": 0,
+}
+
+
 def validate_power(form_factor: str, panel_efficiency: float,
                    enabled_subsystems: dict[str, bool]) -> PowerResult:
     """Validate power budget."""
-    panel_counts = {
-        "1U": 4, "2U": 4, "3U": 6, "6U": 8, "12U": 10,
-        "cansat_standard": 0, "cansat_custom": 0,
-        "rocket_avionics": 0, "rocket_custom": 0,
-        "hab_payload_small": 0, "hab_payload_medium": 0, "hab_payload_large": 0,
-        "drone_small": 0, "drone_medium": 0,
-        "custom": 0,
-    }
-    n_panels = panel_counts.get(form_factor, 0)
+    n_panels = _CANONICAL_PANEL_COUNTS.get(_canonical_key(form_factor), 0)
 
     # Average generation (accounting for eclipse and cosine losses)
     avg_factor = 0.35  # ~35% of orbit sunlit with average cosine


### PR DESCRIPTION
Closes #14.

## Summary

Migrates `configurator/tests/test_validators.py` from the pre-v1.3.0 legacy keys (`"1U"`, `"3U"`, `"6U"`) to the canonical form-factor keys (`cubesat_1u`, `cubesat_3u`, `cubesat_6u`) registered in `flight-software/core/form_factors.py`, per the scope list in the issue.

`test_legacy_keys_still_work` is deliberately untouched — it is the explicit regression guard that legacy aliases continue to resolve via the `_ALIASES` tables in `mass_validator.py` and `volume_validator.py`.

## One extra change: `power_validator` drift

The issue's scope lists `test_power_*` alongside mass/volume. Migrating those three tests (`test_power_3u_positive_balance`, `test_power_generation_increases_with_panels`, and the `"3U"` / `"6U"` references in the peak + subsystems tests) exposed a drift point: unlike `mass_validator.py` and `volume_validator.py`, `power_validator.py` had its `panel_counts` dict hardcoded with legacy keys only and no `_ALIASES` table, so `validate_power("cubesat_3u", …)` silently dropped `n_panels` to 0 and failed `generation_w > 0`.

Fixed by giving `power_validator` the same `_ALIASES` pattern the other two validators use, and keying the internal `_CANONICAL_PANEL_COUNTS` dict off canonical names. The public API is unchanged — `"3U"` and `"cubesat_3u"` now both resolve to the same panel count, matching the behavior of `validate_mass` and `validate_volume`.

## Verification

```
$ cd configurator && python3 -m pytest tests/test_validators.py -q
.....................                                                    [100%]
21 passed in 0.02s
```

Definition-of-done items from the issue body:

- [x] Every test except `test_legacy_keys_still_work` uses canonical keys.
- [x] `pytest configurator/tests/ -q` reports `21 passed`.
- [x] `test_legacy_keys_still_work` still explicitly exercises `"3U"` against `"cubesat_3u"`.

The `_ALIASES` tables in `mass_validator.py` / `volume_validator.py` are untouched, per the issue's don't-touch list.