### PR TITLE
docs(missions): add index page and pack template

### DIFF
--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -1,0 +1,56 @@
+# Mission packs
+
+Each subdirectory under `docs/missions/` is a complete **mission pack**: the full
+documentation set for one specific science mission on a UniSat platform. A mission
+pack ships every artefact a competition jury or internal CDR review needs in one
+place — design review, science justification, key-data format, presentation,
+poster, compliance checklist, and a baseline SITL dataset.
+
+If you are starting a new mission, copy [`_template/`](_template/) and fill in
+the seven canonical documents.
+
+## Index
+
+| Mission | Science objective | Form factor | Template preset | Pack |
+| --- | --- | --- | --- | --- |
+| `cansat_radiation` | Vertical gamma dose-rate profile 0–500 m at ≤ 10 m resolution (SBM-20 Geiger tube) | `cansat_standard` (Ø 68 × 80 mm, ≤ 500 g) | [`cansat_uzcansat.json`](../../mission_templates/cansat_uzcansat.json), [`cansat_standard.json`](../../mission_templates/cansat_standard.json) | [pack](cansat_radiation/) |
+
+> Future mission packs (hyperspectral 6U Earth observation, 3U SSO technology
+> demonstrator, HAB telemetry) will be added here as they ship. See
+> [`docs/budgets/mass_budget.md`](../budgets/mass_budget.md) for the upcoming
+> form-factor budgets that pack authors should target.
+
+## What a complete mission pack contains
+
+The seven canonical documents come from the `cansat_radiation` precedent — the
+first pack that closed all four UzCanSat 2026 regulatory weaknesses. Each pack
+should include:
+
+| Document | Purpose |
+| --- | --- |
+| `README.md` | One-page overview: mission, form factor, document map, related tools. |
+| `CDR.md` | Critical Design Review — ConOps, requirements, subsystems, tests, REQ-traceability. |
+| `SCIENCE_MISSION.md` | Hypotheses (H₀/H₁), sensor justification, expected data, analysis method. |
+| `KEY_DATA_PACKET.md` | On-the-wire format for the key-data beacon plus a fallback plan. |
+| `PRESENTATION.md` | Marp slide deck (10 slides) with talking points in HTML comments. |
+| `POSTER.md` | A0 poster layout in ASCII plus typesetting notes. |
+| `*_COMPLIANCE.md` | Regulation-specific checklist (UzCanSat, CanSat Russia, ESA, …). |
+
+A baseline SITL dataset (`baseline_sitl_dataset.csv`) is strongly recommended so
+post-flight analysis scripts can be regression-tested against a known-good
+trajectory.
+
+The mission template preset (the `mission_templates/*.json` file) lives **outside**
+the mission pack so it stays in the canonical templates location; the pack
+references it from `README.md`.
+
+## Authoring a new pack
+
+1. `cp -r docs/missions/_template/ docs/missions/<your_mission>/`
+2. Fill in each of the seven documents. Keep the section structure — readers
+   navigate by it across packs.
+3. Add the corresponding `mission_templates/<your_mission>.json` preset (see
+   existing presets for shape).
+4. Append a row to the **Index** table above.
+5. If your mission targets a specific competition, add a `<competition>_COMPLIANCE.md`
+   modelled on [`cansat_radiation/UZCANSAT_COMPLIANCE.md`](cansat_radiation/UZCANSAT_COMPLIANCE.md).

--- a/docs/missions/_template/CDR.md
+++ b/docs/missions/_template/CDR.md
@@ -1,0 +1,88 @@
+# Critical Design Review — <Mission name>
+
+**Mission:** one-sentence statement of the science / engineering objective.
+
+**Form factor:** `<cansat_standard | cubesat_1u | …>` — physical envelope, mass
+budget, applicable platform standard.
+
+**Team:** *[team name]* · Contact: *[email]* · Code: [github.com/root3315/unisat](https://github.com/root3315/unisat)
+
+---
+
+## 1. Concept of Operations (ConOps)
+
+```
+t=0s    Ground checkout       → describe what is verified before launch
+t=Ns    Launch                → describe trigger and detection
+t+30s   Ascent (~h m)         → describe ascent envelope
+t+35s   Apogee / ejection     → describe deployment
+t+36s   Descent ~v m/s        → describe data collection schedule
+t+95s   Landed                → describe landing artefacts and beacon
+```
+
+State the total flight duration and which subsystems are active at each phase.
+
+---
+
+## 2. Science / engineering objective
+
+Reference [`SCIENCE_MISSION.md`](SCIENCE_MISSION.md) and summarise here in three
+to five bullets. State what makes this mission non-trivial relative to a
+generic telemetry-only baseline.
+
+---
+
+## 3. Requirements (REQ traceability)
+
+| ID | Requirement | Verification | Section |
+| --- | --- | --- | --- |
+| REQ-001 | … | test / inspection / analysis | §x |
+| REQ-002 | … | … | … |
+
+Every requirement listed here must be traceable to a verification activity in
+§7 and to the corresponding line in `<COMPETITION>_COMPLIANCE.md`.
+
+---
+
+## 4. Subsystems
+
+For each subsystem (power, comms, ADCS, payload, GNSS, …) describe:
+
+- Components and part numbers.
+- Interfaces (electrical, mechanical, data) — link to ICDs.
+- Failure modes and mitigations.
+- Mass / power / data-rate budget contribution.
+
+---
+
+## 5. Mass / power / data budgets
+
+Reference [`docs/budgets/`](../../budgets/) and summarise the values for this
+mission. Highlight any line item over 80 % of its allocation.
+
+---
+
+## 6. Risk register
+
+| Risk | Likelihood | Severity | Mitigation |
+| --- | --- | --- | --- |
+| … | L / M / H | L / M / H | … |
+
+---
+
+## 7. Verification plan
+
+Enumerate the tests that close every requirement from §3. Each row should
+reference a script, fixture, or procedure that can be re-run.
+
+| Test | Closes | Method | Artefact |
+| --- | --- | --- | --- |
+| TEST-001 | REQ-001 | SITL run on `baseline_sitl_dataset.csv` | log path |
+| … | … | … | … |
+
+---
+
+## 8. Open issues
+
+A short list of decisions still pending. Each item should have an owner and a
+target review date.

--- a/docs/missions/_template/COMPLIANCE.md
+++ b/docs/missions/_template/COMPLIANCE.md
@@ -1,0 +1,30 @@
+# <Competition> compliance — <Mission name>
+
+Rename this file to match the target competition (for example
+`UZCANSAT_COMPLIANCE.md`, `CANSAT_RU_COMPLIANCE.md`, `ESA_FLY_YOUR_SAT_COMPLIANCE.md`).
+Each row should map a regulation clause to the mission artefact that closes it,
+so that a jury reviewer can sign off without leaving the document.
+
+## Reference
+
+- Regulation document: link to the official PDF / DOC.
+- Version / edition: date the competition published.
+
+## Checklist
+
+| § | Clause | Requirement | Mission artefact | Status |
+| --- | --- | --- | --- | --- |
+| 1.x | Section title | Plain-text restatement | `path/to/file.md` § y | Closed / Open / N/A |
+| … | … | … | … | … |
+
+## Open items
+
+For every "Open" row above, state the planned closure date and the owner. If
+an "N/A" requires justification (for example, a power class that this form
+factor cannot exceed), state the justification here.
+
+## References
+
+If the regulation requires citing source documents, list them under
+`references/` next to this file. Include both the original-language version
+and any translation that the team relied on.

--- a/docs/missions/_template/KEY_DATA_PACKET.md
+++ b/docs/missions/_template/KEY_DATA_PACKET.md
@@ -1,0 +1,47 @@
+# Key-data packet — <Mission name>
+
+The "key data" packet is the smallest possible payload that, on its own, lets
+recovery teams reconstruct the mission outcome even if no other artefact
+survives the flight. It is transmitted at landing and should fit in a single
+beacon frame.
+
+## Format
+
+```c
+struct mission_beacon_t {
+    uint32_t mission_id;
+    uint32_t timestamp_unix;
+    int32_t  lat_e7;          // degrees * 1e7
+    int32_t  lon_e7;
+    int16_t  alt_m;
+    // mission-specific fields below this line
+} __attribute__((packed));
+```
+
+Fill in the mission-specific fields. Keep the packet ≤ 64 bytes so that any
+downlink budget can carry it.
+
+## Triple redundancy
+
+The packet should be transmitted at least three times by independent paths:
+
+1. **In-flight beacon** — broadcast on the platform's primary RF link as soon
+   as the science phase ends.
+2. **Landing beacon** — broadcast for at least 60 seconds after touchdown
+   detection, with a duty cycle that survives a low-battery scenario.
+3. **Persistent storage** — written to the SD card and to internal flash so
+   that physical recovery of either survives.
+
+## Fallback plan
+
+Document what happens if the primary downlink fails:
+
+- Which subsystem owns the fallback transmission.
+- Which fields can be reconstructed from raw telemetry on the SD card.
+- Which fields are unrecoverable and why.
+
+## Checksum
+
+Specify the checksum or signature scheme the recovery team uses to validate
+the packet (CRC-16, CMAC, HMAC-SHA256-truncated, …) and where the verification
+key lives.

--- a/docs/missions/_template/POSTER.md
+++ b/docs/missions/_template/POSTER.md
@@ -1,0 +1,39 @@
+# POSTER — <Mission name>
+
+A0 portrait poster (841 × 1189 mm). Source layout in ASCII below; render with
+your preferred typesetting tool (LaTeX `tikzposter`, Marp, or SVG).
+
+## ASCII layout
+
+```
++----------------------------------------------------------+
+|  TITLE: <mission name> — one-line subtitle               |
+|  TEAM: name · institution · contact                      |
++----------------------------------------------------------+
+|  ABSTRACT                                                 |
+|  3-4 sentences. Question, method, result.                 |
++--------------------------+--------------------------------+
+|  SCIENCE QUESTION        |  CONOPS                        |
+|  H0 / H1 / decision rule |  ASCII flow diagram            |
++--------------------------+--------------------------------+
+|  PAYLOAD                 |  KEY DATA                      |
+|  Sensor table            |  Beacon format + sample row    |
++--------------------------+--------------------------------+
+|  SUBSYSTEMS              |  VERIFICATION                  |
+|  Block diagram           |  Test → REQ traceability       |
++--------------------------+--------------------------------+
+|  RESULTS / EXPECTED RESULTS                                |
+|  Plot, plot, plot. The poster's most-read square.         |
++----------------------------------------------------------+
+|  REPOSITORY: github.com/root3315/unisat                  |
+|  LICENCE: Apache 2.0   ·   QR CODE        ·   v1.x.y     |
++----------------------------------------------------------+
+```
+
+## Typesetting notes
+
+- Top stripe: project banner. Use the same hero image as `README.md` if there
+  is one.
+- Body grid: 2 columns × 4 rows fills the page well at 12 pt body / 24 pt headers.
+- Bottom stripe: keep the QR code under 80 × 80 mm so it scans from 1.5 m.
+- Avoid screenshots of code. Use renderings of plots from the analysis script.

--- a/docs/missions/_template/PRESENTATION.md
+++ b/docs/missions/_template/PRESENTATION.md
@@ -1,0 +1,106 @@
+---
+marp: true
+theme: default
+paginate: true
+---
+
+<!--
+PRESENTATION.md is a Marp slide deck. Render with `marp PRESENTATION.md` or
+preview in VS Code's Marp extension. Talking points live in HTML comments
+under each slide so they do not appear in the rendered deck but are still
+version-controlled with the slide.
+
+Target: 10 slides, 10 minutes including Q&A.
+-->
+
+# <Mission name>
+
+<!-- Talking points: introduce the team, the mission name, and the platform. -->
+
+---
+
+## Mission objective
+
+- One bullet: the science / engineering question.
+- One bullet: why it is non-trivial.
+- One bullet: why it fits the chosen form factor.
+
+<!-- Talking points: state H₀ / H₁ in plain language. -->
+
+---
+
+## Concept of operations
+
+```
+launch → ascent → apogee → descent → landed
+```
+
+<!-- Talking points: walk through the flight phases and call out the
+science-collection window. -->
+
+---
+
+## Subsystems
+
+| Subsystem | Choice | Why |
+| --- | --- | --- |
+| Power | … | … |
+| Comms | … | … |
+| Payload | … | … |
+
+<!-- Talking points: highlight the one subsystem that drove the design. -->
+
+---
+
+## Science measurement
+
+- Quantity, units, resolution.
+- Expected magnitude and uncertainty.
+- Sample count over the mission.
+
+<!-- Talking points: contrast the expected H₁ result with H₀. -->
+
+---
+
+## Verification
+
+- SITL coverage: which scripts run against `baseline_sitl_dataset.csv`.
+- Hardware-in-the-loop: which subsystems are exercised on bench.
+- Field test: what was demonstrated end-to-end before flight.
+
+<!-- Talking points: name the one test that closes the highest-risk REQ. -->
+
+---
+
+## Risk register highlights
+
+- Top three risks and their mitigations.
+
+<!-- Talking points: be honest about residual risk. Juries reward this. -->
+
+---
+
+## Compliance summary
+
+- One line per regulation: how this mission meets it.
+
+<!-- Talking points: reference `<COMPETITION>_COMPLIANCE.md` for the full list. -->
+
+---
+
+## Schedule and team
+
+- Major milestones with dates.
+- Team roles.
+
+<!-- Talking points: end with the next dated deliverable. -->
+
+---
+
+## Questions
+
+- Contact email.
+- Repository URL.
+- Where the data will be published after the flight.
+
+<!-- Talking points: leave 2 minutes for Q&A. -->

--- a/docs/missions/_template/README.md
+++ b/docs/missions/_template/README.md
@@ -1,0 +1,35 @@
+# <Mission name> — full mission documentation pack
+
+Brief mission statement: what science / engineering objective this pack covers,
+on which UniSat form factor (`cansat_standard`, `cubesat_3u`, …) and against
+which competition or operational target.
+
+## Document map
+
+```
+docs/missions/<mission_dir>/
+├── README.md              ← this file
+├── CDR.md                 ← Critical Design Review
+├── SCIENCE_MISSION.md     ← H₀/H₁, sensor justification, analysis method
+├── KEY_DATA_PACKET.md     ← key-data on-the-wire format and fallback plan
+├── PRESENTATION.md        ← Marp slide deck (10 slides) with talking points
+├── POSTER.md              ← A0 poster layout in ASCII plus typesetting notes
+├── <COMPETITION>_COMPLIANCE.md ← regulation checklist (rename per competition)
+└── baseline_sitl_dataset.csv   ← optional but strongly recommended
+```
+
+The mission's template preset lives outside this directory at
+`mission_templates/<mission_name>.json` so it stays in the canonical templates
+location; reference it from this README.
+
+## Related tools
+
+- `scripts/<analysis_script>.py` — post-flight CSV processor for this mission's
+  key data (delete this section if no mission-specific analysis exists).
+
+## How to use this template
+
+1. Copy `docs/missions/_template/` to `docs/missions/<your_mission>/`.
+2. Fill in each canonical document. Keep section headings stable so that
+   reviewers can navigate across packs by structure.
+3. Append a row to [`docs/missions/README.md`](../README.md) under **Index**.

--- a/docs/missions/_template/SCIENCE_MISSION.md
+++ b/docs/missions/_template/SCIENCE_MISSION.md
@@ -1,0 +1,42 @@
+# Science mission — <Mission name>
+
+## 1. Question
+
+State the scientific or engineering question this mission answers in one
+sentence. Avoid vague framings like "collect telemetry": commit to a specific
+measurable quantity.
+
+## 2. Hypotheses
+
+- **H₀ (null):** what we expect to observe under the no-effect assumption.
+- **H₁ (alternative):** what we expect to observe if the effect is real.
+- Decision rule: how the collected data will discriminate between H₀ and H₁.
+
+## 3. Sensor selection
+
+For each primary sensor, justify the choice against at least five criteria:
+
+1. Sensitivity to the target signal at the expected magnitude.
+2. Mass and power compatibility with the form-factor budget.
+3. Interface compatibility with the platform (I²C, SPI, UART, GPIO capture, …).
+4. Time response vs. flight phase duration.
+5. Heritage / availability under the project's procurement constraints.
+
+## 4. Expected data product
+
+Describe what the mission outputs at the end of the flight:
+
+- Quantity, units, and resolution of the primary measurement.
+- Sampling cadence and total sample count.
+- File format and where it is stored on the platform.
+
+## 5. Analysis method
+
+Describe the post-flight analysis pipeline. Reference scripts under
+`scripts/` and any baseline SITL dataset used for regression testing.
+
+## 6. Originality
+
+State explicitly what makes this mission non-trivial. A jury or reviewer
+should be able to read this section and tell why the team is not just
+re-running a generic baseline.


### PR DESCRIPTION
Resolves #20.

Adds the two deliverables called out in the issue:

### 1. `docs/missions/README.md` — index + comparison

Index table that lists every shipped mission pack (currently `cansat_radiation`) with science objective, form factor, recommended `mission_templates/*.json` presets, and a link to the pack. Future packs (hyperspectral 6U Earth observation, 3U SSO demonstrator, HAB telemetry) will append rows here as they ship.

The README also documents:

- The seven canonical documents a complete mission pack should contain (`README`, `CDR`, `SCIENCE_MISSION`, `KEY_DATA_PACKET`, `PRESENTATION`, `POSTER`, `*_COMPLIANCE`).
- The recommendation to ship a `baseline_sitl_dataset.csv` for regression testing.
- The convention that the mission template preset stays in `mission_templates/` rather than the pack.
- A short authoring flow for new packs.

### 2. `docs/missions/_template/` — blueprint directory

Skeleton versions of all seven canonical documents:

- `README.md` — pack overview with the document map and a "How to use this template" section.
- `CDR.md` — sections for ConOps, requirements (REQ traceability), subsystems, mass/power/data budgets, risk register, verification plan, open items.
- `SCIENCE_MISSION.md` — H₀/H₁ framing, sensor selection criteria, expected data, analysis method, originality.
- `KEY_DATA_PACKET.md` — packed C struct skeleton, triple-redundancy expectations, fallback plan, checksum guidance.
- `PRESENTATION.md` — 10-slide Marp deck with talking points in HTML comments per slide.
- `POSTER.md` — A0 portrait ASCII layout plus typesetting notes.
- `COMPLIANCE.md` — clause-to-artefact mapping table, with rename guidance for the target competition.

Each skeleton preserves the section structure `cansat_radiation/` standardised so reviewers can navigate across packs by structure.