### PR TITLE
chore(docs,test): close DoD gaps from #20 and #22

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ One file per concern, organised by purpose. Start here if you are new.
 |---|---|
 | Clone, build, and fly a reference mission | [`guides/USAGE_GUIDE.md`](guides/USAGE_GUIDE.md) → [`guides/OPERATIONS_GUIDE.md`](guides/OPERATIONS_GUIDE.md) |
 | Pick the right mission profile | [`ops/README.md`](ops/README.md) |
+| Browse a complete mission pack (CDR + science + key data) | [`missions/README.md`](missions/README.md) |
 | Understand how the system fits together | [`design/architecture.md`](design/architecture.md) |
 | Know what works and what is still TODO | [`project/GAPS_AND_ROADMAP.md`](project/GAPS_AND_ROADMAP.md) |
 | Look up an API | [`reference/API_REFERENCE.md`](reference/API_REFERENCE.md) |
@@ -27,6 +28,16 @@ Granular ops for a specific vehicle class: setup → build → flight → post-f
 - CubeSat: [`cubesat_1u`](ops/cubesat_1u.md), [`cubesat_1_5u`](ops/cubesat_1_5u.md), [`cubesat_2u`](ops/cubesat_2u.md), [`cubesat_3u`](ops/cubesat_3u.md), [`cubesat_6u`](ops/cubesat_6u.md), [`cubesat_12u`](ops/cubesat_12u.md)
 - Other platforms: [`rocket_avionics`](ops/rocket_avionics.md), [`hab_payload`](ops/hab_payload.md), [`drone`](ops/drone.md)
 - Index + selection flowchart: [`ops/README.md`](ops/README.md)
+
+## `missions/` — full mission documentation packs
+
+Each subdirectory is a complete mission pack: CDR, science rationale, key-data
+format, presentation, poster, compliance checklist, and (recommended) a baseline
+SITL dataset. Use this when you need an end-to-end worked example.
+
+- Index + comparison table: [`missions/README.md`](missions/README.md)
+- Blueprint for new packs: [`missions/_template/`](missions/_template/)
+- Shipped pack: [`missions/cansat_radiation/`](missions/cansat_radiation/) — vertical gamma dose-rate profile (SBM-20 Geiger tube), targets `cansat_standard`.
 
 ## `design/` — architecture and design decisions
 

--- a/scripts/tests/test_analyze_cansat_radiation.py
+++ b/scripts/tests/test_analyze_cansat_radiation.py
@@ -124,7 +124,7 @@ def test_anomaly_threshold_flags_a_handcrafted_burst(acr, tmp_path):
             })
 
     rows = acr.analyze(csv_path, bin_width_m=20.0)
-    target = [r for r in rows if r["altitude_min"] <= 100.0 < r["altitude_max"]] if False else [
+    target = [
         r for r in rows if r["altitude_mid_m"] == pytest.approx(110.0, abs=0.5)
     ]
     assert target, f"expected a 100-120m bin, got {[r['altitude_bin_m'] for r in rows]}"


### PR DESCRIPTION
Maintenance follow-up after merging #21 and #22. Closes the two small gaps that were called out during review but didn't block the merges.

## Why

**DoD gap from #20 (PR #21):** the issue's Definition of Done required `docs/README.md` to link to `docs/missions/README.md`. PR #21 shipped the new index and template but did not touch the docs root, so the new index was unreachable from the top-level docs page.

**Refactor leftover from PR #22:** `scripts/tests/test_analyze_cansat_radiation.py:127` had a `[...] if False else [...]` expression — the first arm is dead code. Cosmetic only, but worth dropping while it's still recent.

## What changes

- **`docs/README.md`** — adds a row to the Quick paths table (\`Browse a complete mission pack\` → \`missions/README.md\`) plus a dedicated \`## missions/\` section between \`ops/\` and \`design/\`. The placement reflects the user flow: pick form factor (ops) → see worked missions for that form factor (missions) → understand architecture (design).
- **`scripts/tests/test_analyze_cansat_radiation.py`** — drops the dead-code arm of the \`if False else\` expression in \`test_anomaly_threshold_flags_a_handcrafted_burst\`. The active arm is unchanged, so the test continues to assert the same condition.

## Verification

\`\`\`
$ python -m pytest scripts/tests -q
.....                                                                    [100%]
5 passed in 0.87s

$ python -m pytest simulation/tests scripts/tests -q
..............................................................          [100%]
62 passed, 1 warning in 3.90s
\`\`\`

Pure docs + 1-line test cleanup — no functional change.