### PR TITLE
test(flight-software): regression guard for mission templates

### DIFF
--- a/flight-software/tests/test_mission_template_roundtrip.py
+++ b/flight-software/tests/test_mission_template_roundtrip.py
@@ -1,0 +1,93 @@
+"""Regression guard for mission_templates/*.json.
+
+For every JSON file under ``mission_templates/``, parse it and feed the
+result through ``build_profile_from_config()``. The resulting
+``MissionProfile`` must satisfy a small set of non-trivial invariants —
+this catches a class of typos the form-factor validator does not, such as
+a renamed phase key or a typo'd initial phase, by checking that the
+profile actually round-trips end-to-end.
+
+Closes the looser claim in mission_templates/README.md that every shipped
+template is a valid end-to-end profile, complementing
+``configurator/tests/test_validators.py::test_every_template_references_a_known_form_factor``
+which only checks the ``satellite.form_factor`` field.
+
+See issue #17 for context.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mission_types import (
+    MissionProfile,
+    PhaseDefinition,
+    PlatformCategory,
+    build_profile_from_config,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATES_DIR = REPO_ROOT / "mission_templates"
+TEMPLATE_PATHS = sorted(TEMPLATES_DIR.glob("*.json"))
+
+
+def test_templates_directory_is_populated() -> None:
+    """Sanity check: the parametrised test below is meaningless if no
+    templates were found (e.g. the directory was renamed). Fail loudly
+    so the gap shows up as a real test failure, not as 0 collected tests.
+    """
+    assert TEMPLATE_PATHS, (
+        f"No mission_templates/*.json found at {TEMPLATES_DIR}. "
+        "Did the directory move?"
+    )
+
+
+@pytest.mark.parametrize(
+    "template_path",
+    TEMPLATE_PATHS,
+    ids=lambda p: p.name,
+)
+def test_every_template_builds_into_valid_profile(template_path: Path) -> None:
+    """Every shipped mission template must build into a valid
+    ``MissionProfile`` via ``build_profile_from_config``.
+    """
+    config = json.loads(template_path.read_text(encoding="utf-8"))
+    profile = build_profile_from_config(config)
+
+    assert isinstance(profile, MissionProfile), (
+        f"{template_path.name}: build_profile_from_config returned "
+        f"{type(profile).__name__!r}, expected MissionProfile"
+    )
+
+    assert profile.mission_type is not None, (
+        f"{template_path.name}: mission_type is None"
+    )
+
+    assert isinstance(profile.platform, PlatformCategory), (
+        f"{template_path.name}: platform is not a PlatformCategory enum value "
+        f"(got {profile.platform!r})"
+    )
+
+    assert profile.phases, (
+        f"{template_path.name}: phases is empty -- a profile needs at least "
+        "one phase to be runnable"
+    )
+    for phase in profile.phases:
+        assert isinstance(phase, PhaseDefinition), (
+            f"{template_path.name}: phases contains a "
+            f"{type(phase).__name__!r}, expected PhaseDefinition"
+        )
+
+    phase_names = {p.name for p in profile.phases}
+    assert profile.initial_phase in phase_names, (
+        f"{template_path.name}: initial_phase {profile.initial_phase!r} is "
+        f"not one of the phase names {sorted(phase_names)}"
+    )
+
+    assert profile.default_telemetry_hz > 0, (
+        f"{template_path.name}: default_telemetry_hz must be positive, got "
+        f"{profile.default_telemetry_hz}"
+    )


### PR DESCRIPTION
## Summary

Closes #17.

Adds a parametrised regression test that iterates every `mission_templates/*.json` (14 today, including the new `cansat_uzcansat.json` preset shipped in v1.5.1) through `build_profile_from_config()` and asserts a small set of non-trivial invariants on the returned `MissionProfile`:

- `mission_type` is set
- `platform` is a `PlatformCategory` enum value
- `phases` is non-empty and every entry is a `PhaseDefinition`
- `initial_phase` resolves to one of the phase names (catches a typo'd or stale phase reference)
- `default_telemetry_hz` is positive

This catches the failure modes the issue body called out: a renamed key, a typo'd phase name, or a dataclass-shape change in `flight-software/core/mission_types.py` would now fail a real pytest test instead of being silently accepted.

A second test, `test_templates_directory_is_populated`, fails loudly if `mission_templates/` is empty or moved, so the parametrised test cannot silently collect 0 cases (e.g. if the directory is ever renamed).

Complements `configurator/tests/test_validators.py::test_every_template_references_a_known_form_factor`, which only checks the `satellite.form_factor` field.

## Definition of done

- [x] New test in `flight-software/tests/test_mission_template_roundtrip.py` parametrised over every JSON in `mission_templates/`.
- [x] All 14 currently shipped templates pass.
- [x] A deliberately broken template (e.g. `initial_phase` pointing to a non-existent phase) was verified to fail the new assertion locally.

## Verification

```
$ python3 -m pytest tests/test_mission_template_roundtrip.py -v
collected 15 items

tests/test_mission_template_roundtrip.py::test_templates_directory_is_populated PASSED
tests/test_mission_template_roundtrip.py::test_every_template_builds_into_valid_profile[cansat_advanced.json] PASSED
tests/test_mission_template_roundtrip.py::test_every_template_builds_into_valid_profile[cansat_minimal.json] PASSED
... (12 more) ...
tests/test_mission_template_roundtrip.py::test_every_template_builds_into_valid_profile[rocket_competition.json] PASSED

15 passed in 0.02s
```

The unrelated `tests/test_orbit_predictor.py` collection error (`sgp4.earth_gravity`) reproduces on `main` without these changes and is not introduced by this PR.

No production code changes. One new test file. No new dependencies.